### PR TITLE
fix: Improve CLI help consistency and add command descriptions

### DIFF
--- a/agent_manager/agent_manager.py
+++ b/agent_manager/agent_manager.py
@@ -5,11 +5,10 @@
 import argparse
 import sys
 
-from agent_manager.output import MessageType, VerbosityLevel, get_output, message
 from agent_manager.cli_extensions import AgentCommands, ConfigCommands, MergerCommands, RepoCommands
 from agent_manager.config import Config
 from agent_manager.core import create_default_merger_registry, update_repositories
-
+from agent_manager.output import MessageType, VerbosityLevel, get_output, message
 
 # Grouped command help text
 COMMAND_GROUPS = """

--- a/agent_manager/cli_extensions/agent_commands.py
+++ b/agent_manager/cli_extensions/agent_commands.py
@@ -26,18 +26,34 @@ class AgentCommands:
         agents_subparsers = agents_parser.add_subparsers(dest="agents_command", help="Agent commands")
 
         # agents list
-        agents_subparsers.add_parser("list", help="List available agent plugins")
+        agents_subparsers.add_parser(
+            "list",
+            help="List available agent plugins",
+            description="Show all discovered agent plugins, including their package names and enabled/disabled status.",
+        )
 
         # agents enable
-        enable_parser = agents_subparsers.add_parser("enable", help="Enable an agent plugin")
+        enable_parser = agents_subparsers.add_parser(
+            "enable",
+            help="Enable an agent plugin",
+            description="Re-enable a previously disabled agent plugin so it will be included when running 'agent-manager run'.",
+        )
         enable_parser.add_argument("name", help="Agent name (e.g., claude)")
 
         # agents disable
-        disable_parser = agents_subparsers.add_parser("disable", help="Disable an agent plugin")
+        disable_parser = agents_subparsers.add_parser(
+            "disable",
+            help="Disable an agent plugin",
+            description="Disable an agent plugin so it will be skipped when running 'agent-manager run'. The plugin remains installed but inactive.",
+        )
         disable_parser.add_argument("name", help="Agent name (e.g., claude)")
 
         # Run command (default action)
-        run_parser = subparsers.add_parser("run", help="Run an agent (default command)")
+        run_parser = subparsers.add_parser(
+            "run",
+            help="Run an agent (default command)",
+            description="Merge configurations from the hierarchy and apply them to the specified agent(s). This updates repositories, merges files using type-aware strategies, and writes the result to each agent's configuration directory.",
+        )
         run_parser.add_argument(
             "--agent",
             type=str,

--- a/agent_manager/cli_extensions/agent_commands.py
+++ b/agent_manager/cli_extensions/agent_commands.py
@@ -108,7 +108,9 @@ class AgentCommands:
                 MessageType.NORMAL,
                 VerbosityLevel.ALWAYS,
             )
-            message("Agent plugins have package names starting with 'am_agent_'", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message(
+                "Agent plugins have package names starting with 'am_agent_'", MessageType.NORMAL, VerbosityLevel.ALWAYS
+            )
             message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
             return
 

--- a/agent_manager/cli_extensions/agent_commands.py
+++ b/agent_manager/cli_extensions/agent_commands.py
@@ -130,7 +130,6 @@ class AgentCommands:
             message("Use 'agent-manager agents enable <name>' to re-enable", MessageType.NORMAL, VerbosityLevel.ALWAYS)
             message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
 
-        total = len(plugins) + len(disabled)
         message(f"Total: {len(plugins)} enabled, {len(disabled)} disabled", MessageType.NORMAL, VerbosityLevel.ALWAYS)
         message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
 

--- a/agent_manager/cli_extensions/agent_commands.py
+++ b/agent_manager/cli_extensions/agent_commands.py
@@ -60,9 +60,13 @@ class AgentCommands:
             args: Parsed command-line arguments
         """
         if not hasattr(args, "agents_command") or args.agents_command is None:
-            message("No agents subcommand specified", MessageType.ERROR, VerbosityLevel.ALWAYS)
-            message("Available commands: list, enable, disable", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            sys.exit(1)
+            message("Usage: agent-manager agents <command>", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("Available commands:", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("  list      List available agent plugins", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("  enable    Enable an agent plugin", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("  disable   Disable an agent plugin", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            return
 
         if args.agents_command == "list":
             cls.list_agents()

--- a/agent_manager/cli_extensions/config_commands.py
+++ b/agent_manager/cli_extensions/config_commands.py
@@ -25,30 +25,54 @@ class ConfigCommands:
         config_subparsers = config_parser.add_subparsers(dest="config_command", help="Configuration commands")
 
         # config init
-        config_subparsers.add_parser("init", help="Initialize or reinitialize configuration")
+        config_subparsers.add_parser(
+            "init",
+            help="Initialize or reinitialize configuration",
+            description="Create a new configuration file at ~/.agent-manager/config.yaml through an interactive setup wizard. If a configuration already exists, it will be re-initialized.",
+        )
 
         # config show
-        show_parser = config_subparsers.add_parser("show", help="Display current hierarchy")
+        show_parser = config_subparsers.add_parser(
+            "show",
+            help="Display current hierarchy",
+            description="Display the current configuration hierarchy, showing each level's name, repository type, and URL in priority order (lowest to highest).",
+        )
         show_parser.add_argument("--resolve-paths", action="store_true", help="Resolve file:// URLs to absolute paths")
 
         # config add
-        add_parser = config_subparsers.add_parser("add", help="Add a new hierarchy level")
+        add_parser = config_subparsers.add_parser(
+            "add",
+            help="Add a new hierarchy level",
+            description="Add a new hierarchy level with a name and repository URL. The level is appended to the end (highest priority) unless --position is specified.",
+        )
         add_parser.add_argument("name", help="Name of the hierarchy level")
         add_parser.add_argument("url", help="Repository URL (git URL or file:// path)")
         add_parser.add_argument("--position", type=int, help="Position to insert (0-based, default: append to end)")
 
         # config remove
-        remove_parser = config_subparsers.add_parser("remove", help="Remove a hierarchy level")
+        remove_parser = config_subparsers.add_parser(
+            "remove",
+            help="Remove a hierarchy level",
+            description="Remove a hierarchy level by name from the configuration. This does not delete any cached repository data on disk.",
+        )
         remove_parser.add_argument("name", help="Name of the hierarchy level to remove")
 
         # config update
-        update_parser = config_subparsers.add_parser("update", help="Update an existing hierarchy level")
+        update_parser = config_subparsers.add_parser(
+            "update",
+            help="Update an existing hierarchy level",
+            description="Change the URL or name of an existing hierarchy level. At least one of --url or --rename must be provided.",
+        )
         update_parser.add_argument("name", help="Name of the hierarchy level to update")
         update_parser.add_argument("--url", help="New repository URL (git URL or file:// path)")
         update_parser.add_argument("--rename", help="New name for the hierarchy level")
 
         # config move
-        move_parser = config_subparsers.add_parser("move", help="Move a hierarchy level to a new position")
+        move_parser = config_subparsers.add_parser(
+            "move",
+            help="Move a hierarchy level to a new position",
+            description="Change the position of a hierarchy level within the priority order. Levels later in the list have higher priority and their values take precedence during merging.",
+        )
         move_parser.add_argument("name", help="Name of the hierarchy level to move")
         move_group = move_parser.add_mutually_exclusive_group(required=True)
         move_group.add_argument("--position", type=int, help="New position (0-based)")
@@ -56,18 +80,34 @@ class ConfigCommands:
         move_group.add_argument("--down", action="store_true", help="Move down one position")
 
         # config validate
-        config_subparsers.add_parser("validate", help="Validate all repository URLs")
+        config_subparsers.add_parser(
+            "validate",
+            help="Validate all repository URLs",
+            description="Check that all repository URLs in the hierarchy are valid and accessible. Reports which repositories pass or fail validation.",
+        )
 
         # config export
-        export_parser = config_subparsers.add_parser("export", help="Export configuration to a file or stdout")
+        export_parser = config_subparsers.add_parser(
+            "export",
+            help="Export configuration to a file or stdout",
+            description="Export the current configuration as YAML to a file or to stdout. Useful for backing up or sharing configurations.",
+        )
         export_parser.add_argument("file", nargs="?", help="Output file (default: stdout)")
 
         # config import
-        import_parser = config_subparsers.add_parser("import", help="Import configuration from a file")
+        import_parser = config_subparsers.add_parser(
+            "import",
+            help="Import configuration from a file",
+            description="Import a configuration from a YAML file, replacing the current configuration. You will be prompted before overwriting an existing configuration.",
+        )
         import_parser.add_argument("file", help="Input file to import")
 
         # config where
-        config_subparsers.add_parser("where", help="Show configuration file location")
+        config_subparsers.add_parser(
+            "where",
+            help="Show configuration file location",
+            description="Show the file paths for the configuration file, config directory, and repos directory, along with whether each exists on disk.",
+        )
 
     @staticmethod
     def process_cli_command(args: argparse.Namespace, config: Config) -> None:

--- a/agent_manager/cli_extensions/config_commands.py
+++ b/agent_manager/cli_extensions/config_commands.py
@@ -5,9 +5,9 @@ import sys
 
 import yaml
 
-from agent_manager.output import MessageType, VerbosityLevel, message
 from agent_manager.config import Config
 from agent_manager.core import create_repo
+from agent_manager.output import MessageType, VerbosityLevel, message
 
 
 class ConfigCommands:

--- a/agent_manager/cli_extensions/merger_commands.py
+++ b/agent_manager/cli_extensions/merger_commands.py
@@ -3,9 +3,9 @@
 import argparse
 import sys
 
-from agent_manager.output import MessageType, VerbosityLevel, message
 from agent_manager.config import Config
 from agent_manager.core import MergerRegistry
+from agent_manager.output import MessageType, VerbosityLevel, message
 from agent_manager.utils import get_disabled_plugins, set_plugin_enabled
 
 

--- a/agent_manager/cli_extensions/merger_commands.py
+++ b/agent_manager/cli_extensions/merger_commands.py
@@ -32,22 +32,42 @@ class MergerCommands:
         mergers_subparsers = mergers_parser.add_subparsers(dest="mergers_command", help="Merger commands")
 
         # mergers list
-        mergers_subparsers.add_parser("list", help="List available merger plugins")
+        mergers_subparsers.add_parser(
+            "list",
+            help="List available merger plugins",
+            description="Show all registered mergers and their file extension mappings, the default fallback merger, and any available but unregistered merger plugins.",
+        )
 
         # mergers show
-        show_parser = mergers_subparsers.add_parser("show", help="Show preferences for a specific merger")
+        show_parser = mergers_subparsers.add_parser(
+            "show",
+            help="Show preferences for a specific merger",
+            description="Display the configurable preferences for a specific merger, including their types, default values, and valid ranges or choices.",
+        )
         show_parser.add_argument("name", help="Merger class name (e.g., JsonMerger)")
 
         # mergers configure
-        configure_parser = mergers_subparsers.add_parser("configure", help="Interactively configure merger preferences")
+        configure_parser = mergers_subparsers.add_parser(
+            "configure",
+            help="Interactively configure merger preferences",
+            description="Interactively prompt for preference values for each configurable merger (e.g., JSON indent level, YAML width) and save the results to the configuration file.",
+        )
         configure_parser.add_argument("--merger", help="Configure only a specific merger (e.g., JsonMerger)")
 
         # mergers enable
-        enable_parser = mergers_subparsers.add_parser("enable", help="Enable a merger plugin")
+        enable_parser = mergers_subparsers.add_parser(
+            "enable",
+            help="Enable a merger plugin",
+            description="Re-enable a previously disabled merger plugin so it will be available for file merging.",
+        )
         enable_parser.add_argument("name", help="Merger name (e.g., smart_markdown)")
 
         # mergers disable
-        disable_parser = mergers_subparsers.add_parser("disable", help="Disable a merger plugin")
+        disable_parser = mergers_subparsers.add_parser(
+            "disable",
+            help="Disable a merger plugin",
+            description="Disable a merger plugin. Disabled mergers will not be available for file merging; files that would use them will fall back to the default merger.",
+        )
         disable_parser.add_argument("name", help="Merger name (e.g., smart_markdown)")
 
     def process_cli_command(self, args: argparse.Namespace, config: Config) -> None:

--- a/agent_manager/cli_extensions/merger_commands.py
+++ b/agent_manager/cli_extensions/merger_commands.py
@@ -32,11 +32,11 @@ class MergerCommands:
         mergers_subparsers = mergers_parser.add_subparsers(dest="mergers_command", help="Merger commands")
 
         # mergers list
-        mergers_subparsers.add_parser("list", help="List registered mergers")
+        mergers_subparsers.add_parser("list", help="List available merger plugins")
 
         # mergers show
         show_parser = mergers_subparsers.add_parser("show", help="Show preferences for a specific merger")
-        show_parser.add_argument("merger", help="Merger class name (e.g., JsonMerger)")
+        show_parser.add_argument("name", help="Merger class name (e.g., JsonMerger)")
 
         # mergers configure
         configure_parser = mergers_subparsers.add_parser("configure", help="Interactively configure merger preferences")
@@ -58,14 +58,20 @@ class MergerCommands:
             config: Configuration manager instance
         """
         if not hasattr(args, "mergers_command") or args.mergers_command is None:
-            message("No mergers subcommand specified", MessageType.ERROR, VerbosityLevel.ALWAYS)
-            message("Available commands: list, show, configure, enable, disable", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            sys.exit(1)
+            message("Usage: agent-manager mergers <command>", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("Available commands:", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("  list        List available merger plugins", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("  show        Show preferences for a specific merger", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("  configure   Interactively configure merger preferences", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("  enable      Enable a merger plugin", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("  disable     Disable a merger plugin", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            return
 
         if args.mergers_command == "list":
             self.list_mergers()
         elif args.mergers_command == "show":
-            self.show_merger(args.merger)
+            self.show_merger(args.name)
         elif args.mergers_command == "configure":
             self.configure_mergers(config, args.merger)
         elif args.mergers_command == "enable":

--- a/agent_manager/cli_extensions/merger_commands.py
+++ b/agent_manager/cli_extensions/merger_commands.py
@@ -83,7 +83,9 @@ class MergerCommands:
             message("Available commands:", MessageType.NORMAL, VerbosityLevel.ALWAYS)
             message("  list        List available merger plugins", MessageType.NORMAL, VerbosityLevel.ALWAYS)
             message("  show        Show preferences for a specific merger", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("  configure   Interactively configure merger preferences", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message(
+                "  configure   Interactively configure merger preferences", MessageType.NORMAL, VerbosityLevel.ALWAYS
+            )
             message("  enable      Enable a merger plugin", MessageType.NORMAL, VerbosityLevel.ALWAYS)
             message("  disable     Disable a merger plugin", MessageType.NORMAL, VerbosityLevel.ALWAYS)
             return

--- a/agent_manager/cli_extensions/repo_commands.py
+++ b/agent_manager/cli_extensions/repo_commands.py
@@ -110,7 +110,9 @@ class RepoCommands:
             message("Use 'agent-manager repos enable <name>' to re-enable", MessageType.NORMAL, VerbosityLevel.ALWAYS)
             message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
 
-        message(f"Total: {len(repo_types)} enabled, {len(disabled)} disabled", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        message(
+            f"Total: {len(repo_types)} enabled, {len(disabled)} disabled", MessageType.NORMAL, VerbosityLevel.ALWAYS
+        )
         message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
 
     @staticmethod
@@ -132,4 +134,3 @@ class RepoCommands:
         """
         if not set_plugin_enabled("repos", name, enabled=False):
             sys.exit(1)
-

--- a/agent_manager/cli_extensions/repo_commands.py
+++ b/agent_manager/cli_extensions/repo_commands.py
@@ -23,18 +23,34 @@ class RepoCommands:
         repos_subparsers = repos_parser.add_subparsers(dest="repos_command", help="Repository commands")
 
         # repos list
-        repos_subparsers.add_parser("list", help="List available repository plugins")
+        repos_subparsers.add_parser(
+            "list",
+            help="List available repository plugins",
+            description="Show all discovered repository type plugins, including their module paths and enabled/disabled status.",
+        )
 
         # repos enable
-        enable_parser = repos_subparsers.add_parser("enable", help="Enable a repository plugin")
+        enable_parser = repos_subparsers.add_parser(
+            "enable",
+            help="Enable a repository plugin",
+            description="Re-enable a previously disabled repository plugin so it can be used in the configuration hierarchy.",
+        )
         enable_parser.add_argument("name", help="Repository name (e.g., git)")
 
         # repos disable
-        disable_parser = repos_subparsers.add_parser("disable", help="Disable a repository plugin")
+        disable_parser = repos_subparsers.add_parser(
+            "disable",
+            help="Disable a repository plugin",
+            description="Disable a repository plugin. Disabled repository types cannot be used in the configuration hierarchy.",
+        )
         disable_parser.add_argument("name", help="Repository name (e.g., git)")
 
         # Update command (keep as separate command for backwards compatibility)
-        update_parser = subparsers.add_parser("update", help="Update all repositories in the hierarchy")
+        update_parser = subparsers.add_parser(
+            "update",
+            help="Update all repositories in the hierarchy",
+            description="Fetch the latest content from all repositories defined in the configuration hierarchy. For git repositories this performs a pull; for local repositories it verifies the directory exists. This does not update agent configurations -- use 'agent-manager run' for that.",
+        )
         update_parser.add_argument(
             "--force", action="store_true", help="Force update even if repository appears up to date"
         )

--- a/agent_manager/cli_extensions/repo_commands.py
+++ b/agent_manager/cli_extensions/repo_commands.py
@@ -23,20 +23,18 @@ class RepoCommands:
         repos_subparsers = repos_parser.add_subparsers(dest="repos_command", help="Repository commands")
 
         # repos list
-        repos_subparsers.add_parser("list", help="List available repository types")
+        repos_subparsers.add_parser("list", help="List available repository plugins")
 
         # repos enable
-        enable_parser = repos_subparsers.add_parser("enable", help="Enable a repository type plugin")
-        enable_parser.add_argument("name", help="Repository type name (e.g., git)")
+        enable_parser = repos_subparsers.add_parser("enable", help="Enable a repository plugin")
+        enable_parser.add_argument("name", help="Repository name (e.g., git)")
 
         # repos disable
-        disable_parser = repos_subparsers.add_parser("disable", help="Disable a repository type plugin")
-        disable_parser.add_argument("name", help="Repository type name (e.g., git)")
+        disable_parser = repos_subparsers.add_parser("disable", help="Disable a repository plugin")
+        disable_parser.add_argument("name", help="Repository name (e.g., git)")
 
         # Update command (keep as separate command for backwards compatibility)
-        update_parser = subparsers.add_parser(
-            "update", help="Update all repositories in the hierarchy (does not update agent configs)"
-        )
+        update_parser = subparsers.add_parser("update", help="Update all repositories in the hierarchy")
         update_parser.add_argument(
             "--force", action="store_true", help="Force update even if repository appears up to date"
         )
@@ -49,9 +47,13 @@ class RepoCommands:
             args: Parsed command-line arguments
         """
         if not hasattr(args, "repos_command") or args.repos_command is None:
-            message("No repos subcommand specified", MessageType.ERROR, VerbosityLevel.ALWAYS)
-            message("Available commands: list, enable, disable", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            sys.exit(1)
+            message("Usage: agent-manager repos <command>", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("Available commands:", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("  list      List available repository plugins", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("  enable    Enable a repository plugin", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("  disable   Disable a repository plugin", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            return
 
         if args.repos_command == "list":
             RepoCommands.list_repos()

--- a/agent_manager/config/config.py
+++ b/agent_manager/config/config.py
@@ -7,8 +7,8 @@ from typing import Any, TypedDict
 
 import yaml
 
-from agent_manager.output import MessageType, VerbosityLevel, message
 from agent_manager.core import create_repo, discover_repo_types
+from agent_manager.output import MessageType, VerbosityLevel, message
 from agent_manager.utils import is_file_url, resolve_file_path
 
 

--- a/agent_manager/config/config.py
+++ b/agent_manager/config/config.py
@@ -379,7 +379,11 @@ class Config:
         # Prompt for hierarchy with retry loop
         hierarchy_list = None
         while hierarchy_list is None:
-            message("Enter your hierarchy levels, from LOWEST to HIGHEST priority.", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message(
+                "Enter your hierarchy levels, from LOWEST to HIGHEST priority.",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
             message("(first = base, last = overrides all)", MessageType.NORMAL, VerbosityLevel.ALWAYS)
             example = "(e.g., organization, team, personal): "
             hierarchy_input = input(example).strip()
@@ -405,7 +409,11 @@ class Config:
 
             # Validate we got at least one level
             if not hierarchy_list:
-                message("Hierarchy must have at least one level. Please try again.\n", MessageType.ERROR, VerbosityLevel.ALWAYS)
+                message(
+                    "Hierarchy must have at least one level. Please try again.\n",
+                    MessageType.ERROR,
+                    VerbosityLevel.ALWAYS,
+                )
                 hierarchy_list = None
                 continue
 

--- a/agent_manager/core/agents.py
+++ b/agent_manager/core/agents.py
@@ -138,4 +138,3 @@ def run_agents(agent_names: list[str], config_data: dict, scope: str = "default"
         except Exception as e:
             message(f"Failed to initialize agent '{agent_name}': {e}", MessageType.ERROR, VerbosityLevel.ALWAYS)
             sys.exit(1)
-

--- a/agent_manager/core/agents.py
+++ b/agent_manager/core/agents.py
@@ -5,7 +5,6 @@ import sys
 from agent_manager.output import MessageType, VerbosityLevel, message
 from agent_manager.utils import discover_external_plugins, filter_disabled_plugins, load_plugin_class
 
-
 # Package prefix for agent plugins
 AGENT_PLUGIN_PREFIX = "am_agent_"
 
@@ -94,10 +93,7 @@ def run_agents(agent_names: list[str], config_data: dict, scope: str = "default"
     plugins = discover_agent_plugins()
 
     # Determine which agents to run
-    if agent_names == ["all"] or "all" in agent_names:
-        agents_to_run = sorted(plugins.keys())
-    else:
-        agents_to_run = agent_names
+    agents_to_run = sorted(plugins.keys()) if agent_names == ["all"] or "all" in agent_names else agent_names
 
     # Check if we have any agents
     if not agents_to_run:

--- a/agent_manager/core/repos.py
+++ b/agent_manager/core/repos.py
@@ -53,7 +53,9 @@ def discover_repo_types(include_disabled: bool = False):
                 if issubclass(obj, AbstractRepo) and obj is not AbstractRepo and obj.__module__ == module.__name__:
                     # Check if this repo type is disabled
                     if hasattr(obj, "REPO_TYPE") and obj.REPO_TYPE in disabled_repos:
-                        message(f"Skipping disabled repo type: {obj.REPO_TYPE}", MessageType.DEBUG, VerbosityLevel.DEBUG)
+                        message(
+                            f"Skipping disabled repo type: {obj.REPO_TYPE}", MessageType.DEBUG, VerbosityLevel.DEBUG
+                        )
                         continue
                     repo_types.append(obj)
 

--- a/agent_manager/plugins/agents/agent.py
+++ b/agent_manager/plugins/agents/agent.py
@@ -473,7 +473,11 @@ class AbstractAgent(ABC):
 
         # Write merged files with POST-MERGE HOOKS
         if merged_files:
-            message(f"\nWriting {len(merged_files)} merged file(s) to {output_dir}...", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message(
+                f"\nWriting {len(merged_files)} merged file(s) to {output_dir}...",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
 
             for file_path_str, (content, sources) in merged_files.items():
                 # POST-MERGE HOOK: Allow plugin-specific postprocessing

--- a/agent_manager/plugins/agents/agent.py
+++ b/agent_manager/plugins/agents/agent.py
@@ -6,8 +6,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
-from agent_manager.output import MessageType, VerbosityLevel, message
 from agent_manager.core import MergerRegistry
+from agent_manager.output import MessageType, VerbosityLevel, message
 
 
 @dataclass
@@ -157,7 +157,7 @@ class AbstractAgent(ABC):
         # Post-merge: Add metadata header to merged files
         self.post_merge_hooks["*"] = self._add_metadata_header
 
-    def register_hooks(self) -> None:
+    def register_hooks(self) -> None:  # noqa: B027
         """Register agent-specific hooks for pre/post merge processing.
 
         Override this method to register additional hooks for specific file patterns.
@@ -168,7 +168,6 @@ class AbstractAgent(ABC):
                 self.pre_merge_hooks[".cursorrules"] = self._validate_cursorrules
                 self.post_merge_hooks["*.json"] = self._format_json
         """
-        pass
 
     def _clean_markdown(self, content: str, entry: dict, file_path: Path) -> str:
         """Clean up markdown content before merging.

--- a/agent_manager/plugins/agents/test_agent.py
+++ b/agent_manager/plugins/agents/test_agent.py
@@ -35,6 +35,18 @@ class TestAgent(AbstractAgent):
     # Set the repo directory name to ".testagent"
     _repo_directory_name: str = ".testagent"
 
+    @property
+    def scopes(self) -> dict:
+        """Define available scopes for the test agent."""
+        from agent_manager.plugins.agents.agent import ScopeConfig
+
+        return {
+            "default": ScopeConfig(
+                directory=self.agent_directory,
+                description="Test agent output directory",
+            ),
+        }
+
     def register_hooks(self):
         """Register any custom hooks for the test agent.
 

--- a/agent_manager/utils/discovery.py
+++ b/agent_manager/utils/discovery.py
@@ -117,7 +117,9 @@ def set_plugin_enabled(
             # Add to disabled list
             if plugin_name not in disabled_list:
                 disabled_list.append(plugin_name)
-                message(f"Disabled {plugin_type[:-1]} plugin: {plugin_name}", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
+                message(
+                    f"Disabled {plugin_type[:-1]} plugin: {plugin_name}", MessageType.SUCCESS, VerbosityLevel.ALWAYS
+                )
             else:
                 message(f"Plugin '{plugin_name}' is already disabled", MessageType.INFO, VerbosityLevel.ALWAYS)
 
@@ -363,4 +365,3 @@ def load_plugin_class(plugin_info: dict, class_name: str = "Agent"):
     # Otherwise, import the module and get the class
     module = importlib.import_module(plugin_info["package_name"])
     return getattr(module, class_name)
-

--- a/agent_manager/utils/discovery.py
+++ b/agent_manager/utils/discovery.py
@@ -9,7 +9,6 @@ import yaml
 
 from agent_manager.output import MessageType, VerbosityLevel, message
 
-
 # =============================================================================
 # Plugin Enable/Disable Utilities
 # =============================================================================
@@ -307,14 +306,15 @@ def _discover_by_entry_points(
                 loaded_class = ep.load()
 
                 # Validate against base class if provided
-                if base_class is not None:
-                    if not (isinstance(loaded_class, type) and issubclass(loaded_class, base_class)):
-                        message(
-                            f"Entry point '{ep.name}' does not point to a valid {plugin_type} class",
-                            MessageType.WARNING,
-                            VerbosityLevel.VERBOSE,
-                        )
-                        continue
+                if base_class is not None and not (
+                    isinstance(loaded_class, type) and issubclass(loaded_class, base_class)
+                ):
+                    message(
+                        f"Entry point '{ep.name}' does not point to a valid {plugin_type} class",
+                        MessageType.WARNING,
+                        VerbosityLevel.VERBOSE,
+                    )
+                    continue
 
                 plugins[ep.name] = {
                     "package_name": ep.value.split(":")[0] if ":" in ep.value else ep.value,

--- a/agent_manager/utils/url.py
+++ b/agent_manager/utils/url.py
@@ -33,10 +33,7 @@ def is_file_url(url: str) -> bool:
         return True
 
     # Current or parent directory
-    if url == "." or url == "..":
-        return True
-
-    return False
+    return bool(url == "." or url == "..")
 
 
 def resolve_file_path(url: str) -> Path:

--- a/tests/cli_extensions/test_agent_commands.py
+++ b/tests/cli_extensions/test_agent_commands.py
@@ -29,8 +29,8 @@ class TestAgentCommandsAddCliArguments:
         assert "run" in calls
 
     @patch("agent_manager.cli_extensions.agent_commands.get_agent_names")
-    def test_adds_agents_list_subcommand(self, mock_get_agent_names):
-        """Test that add_cli_arguments adds list subcommand to agents."""
+    def test_adds_agents_subcommands(self, mock_get_agent_names):
+        """Test that add_cli_arguments adds list, enable, and disable subcommands to agents."""
         mock_get_agent_names.return_value = ["claude"]
 
         mock_subparsers = Mock()
@@ -50,8 +50,11 @@ class TestAgentCommandsAddCliArguments:
 
         AgentCommands.add_cli_arguments(mock_subparsers)
 
-        # Check that list subcommand was added to agents
-        mock_agents_subparsers.add_parser.assert_called_once_with("list", help="List available agent plugins")
+        # Check that list, enable, and disable subcommands were added to agents
+        calls = [call[0][0] for call in mock_agents_subparsers.add_parser.call_args_list]
+        assert "list" in calls
+        assert "enable" in calls
+        assert "disable" in calls
 
     @patch("agent_manager.cli_extensions.agent_commands.get_agent_names")
     def test_adds_agent_argument_with_choices(self, mock_get_agent_names):
@@ -59,15 +62,25 @@ class TestAgentCommandsAddCliArguments:
         mock_get_agent_names.return_value = ["claude", "custom"]
 
         mock_subparsers = Mock()
-        mock_parser = Mock()
-        mock_parser.add_subparsers.return_value = Mock()
-        mock_subparsers.add_parser.return_value = mock_parser
+        mock_agents_parser = Mock()
+        mock_run_parser = Mock()
+
+        def add_parser_side_effect(name, **kwargs):
+            if name == "agents":
+                return mock_agents_parser
+            elif name == "run":
+                return mock_run_parser
+            return Mock()
+
+        mock_subparsers.add_parser.side_effect = add_parser_side_effect
+        mock_agents_parser.add_subparsers.return_value = Mock()
 
         AgentCommands.add_cli_arguments(mock_subparsers)
 
-        # Check that add_argument was called with choices including discovered agents
-        call_args = mock_parser.add_argument.call_args
-        assert call_args[1]["choices"] == ["all", "claude", "custom"]
+        # Check that add_argument was called on the run parser with choices including discovered agents
+        choices_call = [call for call in mock_run_parser.add_argument.call_args_list if "choices" in call[1]]
+        assert len(choices_call) == 1
+        assert choices_call[0][1]["choices"] == ["all", "claude", "custom"]
 
     @patch("agent_manager.cli_extensions.agent_commands.get_agent_names")
     def test_adds_agent_argument_with_no_plugins(self, mock_get_agent_names):
@@ -75,15 +88,25 @@ class TestAgentCommandsAddCliArguments:
         mock_get_agent_names.return_value = []
 
         mock_subparsers = Mock()
-        mock_parser = Mock()
-        mock_parser.add_subparsers.return_value = Mock()
-        mock_subparsers.add_parser.return_value = mock_parser
+        mock_agents_parser = Mock()
+        mock_run_parser = Mock()
+
+        def add_parser_side_effect(name, **kwargs):
+            if name == "agents":
+                return mock_agents_parser
+            elif name == "run":
+                return mock_run_parser
+            return Mock()
+
+        mock_subparsers.add_parser.side_effect = add_parser_side_effect
+        mock_agents_parser.add_subparsers.return_value = Mock()
 
         AgentCommands.add_cli_arguments(mock_subparsers)
 
         # Should still add argument with just "all"
-        call_args = mock_parser.add_argument.call_args
-        assert call_args[1]["choices"] == ["all"]
+        choices_call = [call for call in mock_run_parser.add_argument.call_args_list if "choices" in call[1]]
+        assert len(choices_call) == 1
+        assert choices_call[0][1]["choices"] == ["all"]
 
 
 class TestAgentCommandsProcessCliCommand:
@@ -94,43 +117,63 @@ class TestAgentCommandsProcessCliCommand:
         """Test processing run command for single agent."""
         args = Mock()
         args.agent = "claude"
+        args.scope = "default"
         config_data = {"hierarchy": []}
 
         AgentCommands.process_cli_command(args, config_data)
 
-        mock_run_agents.assert_called_once_with(["claude"], config_data)
+        mock_run_agents.assert_called_once_with(["claude"], config_data, scope="default")
 
     @patch("agent_manager.cli_extensions.agent_commands.run_agents")
     def test_processes_run_command_all_agents(self, mock_run_agents):
         """Test processing run command for all agents."""
         args = Mock()
         args.agent = "all"
+        args.scope = "default"
         config_data = {"hierarchy": []}
 
         AgentCommands.process_cli_command(args, config_data)
 
-        mock_run_agents.assert_called_once_with(["all"], config_data)
+        mock_run_agents.assert_called_once_with(["all"], config_data, scope="default")
 
 
 class TestAgentCommandsProcessAgentsCommand:
     """Test cases for process_agents_command method."""
 
-    def test_no_subcommand_specified(self):
-        """Test error when no agents subcommand is specified."""
+    def test_no_subcommand_shows_usage(self):
+        """Test that no subcommand shows friendly usage message."""
         args = Mock()
         args.agents_command = None
 
-        with patch("agent_manager.cli_extensions.agent_commands.message"):
-            with pytest.raises(SystemExit):
-                AgentCommands.process_agents_command(args)
+        messages = []
 
-    def test_no_agents_command_attribute(self):
-        """Test error when agents_command attribute is missing."""
+        def capture_message(text, *args_inner, **kwargs):
+            messages.append(text)
+
+        with patch("agent_manager.cli_extensions.agent_commands.message", side_effect=capture_message):
+            AgentCommands.process_agents_command(args)
+
+        output = "\n".join(messages)
+        assert "Usage: agent-manager agents <command>" in output
+        assert "Available commands:" in output
+        assert "list" in output
+        assert "enable" in output
+        assert "disable" in output
+
+    def test_no_agents_command_attribute_shows_usage(self):
+        """Test that missing agents_command attribute shows friendly usage."""
         args = Mock(spec=[])  # Mock with no attributes
 
-        with patch("agent_manager.cli_extensions.agent_commands.message"):
-            with pytest.raises(SystemExit):
-                AgentCommands.process_agents_command(args)
+        messages = []
+
+        def capture_message(text, *args_inner, **kwargs):
+            messages.append(text)
+
+        with patch("agent_manager.cli_extensions.agent_commands.message", side_effect=capture_message):
+            AgentCommands.process_agents_command(args)
+
+        output = "\n".join(messages)
+        assert "Usage: agent-manager agents <command>" in output
 
     @patch("agent_manager.cli_extensions.agent_commands.AgentCommands.list_agents")
     def test_processes_list_command(self, mock_list_agents):
@@ -146,9 +189,11 @@ class TestAgentCommandsProcessAgentsCommand:
 class TestAgentCommandsListAgents:
     """Test cases for list_agents method."""
 
+    @patch("agent_manager.cli_extensions.agent_commands.get_disabled_plugins")
     @patch("agent_manager.cli_extensions.agent_commands.discover_agent_plugins")
-    def test_list_agents_with_plugins(self, mock_discover):
+    def test_list_agents_with_plugins(self, mock_discover, mock_disabled):
         """Test listing agents when plugins are available."""
+        mock_disabled.return_value = {}
         mock_discover.return_value = {
             "claude": {"package_name": "am_agent_claude", "source": "package"},
             "custom": {"package_name": "am_agent_custom", "source": "package"},
@@ -168,11 +213,13 @@ class TestAgentCommandsListAgents:
         assert "am_agent_claude" in output
         assert "custom" in output
         assert "am_agent_custom" in output
-        assert "Total: 2 agent(s)" in output
+        assert "Total: 2 enabled, 0 disabled" in output
 
+    @patch("agent_manager.cli_extensions.agent_commands.get_disabled_plugins")
     @patch("agent_manager.cli_extensions.agent_commands.discover_agent_plugins")
-    def test_list_agents_no_plugins(self, mock_discover):
+    def test_list_agents_no_plugins(self, mock_discover, mock_disabled):
         """Test listing agents when no plugins are available."""
+        mock_disabled.return_value = {}
         mock_discover.return_value = {}
 
         messages = []
@@ -188,9 +235,11 @@ class TestAgentCommandsListAgents:
         assert "No agent plugins found" in output
         assert "am_agent_" in output  # Should mention the plugin naming convention
 
+    @patch("agent_manager.cli_extensions.agent_commands.get_disabled_plugins")
     @patch("agent_manager.cli_extensions.agent_commands.discover_agent_plugins")
-    def test_list_agents_sorted(self, mock_discover):
+    def test_list_agents_sorted(self, mock_discover, mock_disabled):
         """Test that agents are listed in sorted order."""
+        mock_disabled.return_value = {}
         mock_discover.return_value = {
             "zebra": {"package_name": "am_agent_zebra", "source": "package"},
             "alpha": {"package_name": "am_agent_alpha", "source": "package"},

--- a/tests/cli_extensions/test_agent_commands.py
+++ b/tests/cli_extensions/test_agent_commands.py
@@ -2,8 +2,6 @@
 
 from unittest.mock import Mock, patch
 
-import pytest
-
 from agent_manager.cli_extensions.agent_commands import AgentCommands
 
 

--- a/tests/cli_extensions/test_config_commands.py
+++ b/tests/cli_extensions/test_config_commands.py
@@ -1,8 +1,6 @@
 """Tests for cli_extensions/config_commands.py - Config CLI commands."""
 
-import sys
-from pathlib import Path
-from unittest.mock import Mock, mock_open, patch
+from unittest.mock import Mock, patch
 
 import pytest
 import yaml
@@ -228,9 +226,8 @@ class TestConfigCommandsProcessCliCommand:
 
         config = Mock(spec=Config)
 
-        with patch("agent_manager.cli_extensions.config_commands.message"):
-            with pytest.raises(SystemExit):
-                ConfigCommands.process_cli_command(args, config)
+        with patch("agent_manager.cli_extensions.config_commands.message"), pytest.raises(SystemExit):
+            ConfigCommands.process_cli_command(args, config)
 
     def test_shows_help_when_no_subcommand(self):
         """Test that no subcommand shows available commands instead of error."""
@@ -276,9 +273,8 @@ class TestConfigCommandsDisplay:
         config = Mock(spec=Config)
         config.exists.return_value = False
 
-        with patch("agent_manager.cli_extensions.config_commands.message"):
-            with pytest.raises(SystemExit):
-                ConfigCommands.display(config)
+        with patch("agent_manager.cli_extensions.config_commands.message"), pytest.raises(SystemExit):
+            ConfigCommands.display(config)
 
     @patch("agent_manager.cli_extensions.config_commands.create_repo")
     def test_display_resolves_paths(self, mock_create, tmp_path):
@@ -330,18 +326,16 @@ class TestConfigCommandsValidateAll:
         }
         config.validate_repo_url.side_effect = [True, False]
 
-        with patch("agent_manager.cli_extensions.config_commands.message"):
-            with pytest.raises(SystemExit):
-                ConfigCommands.validate_all(config)
+        with patch("agent_manager.cli_extensions.config_commands.message"), pytest.raises(SystemExit):
+            ConfigCommands.validate_all(config)
 
     def test_validates_all_errors_when_no_config(self):
         """Test that validate_all errors when config doesn't exist."""
         config = Mock(spec=Config)
         config.exists.return_value = False
 
-        with patch("agent_manager.cli_extensions.config_commands.message"):
-            with pytest.raises(SystemExit):
-                ConfigCommands.validate_all(config)
+        with patch("agent_manager.cli_extensions.config_commands.message"), pytest.raises(SystemExit):
+            ConfigCommands.validate_all(config)
 
 
 class TestConfigCommandsExportConfig:
@@ -410,9 +404,8 @@ class TestConfigCommandsExportConfig:
         config = Mock(spec=Config)
         config.exists.return_value = False
 
-        with patch("agent_manager.cli_extensions.config_commands.message"):
-            with pytest.raises(SystemExit):
-                ConfigCommands.export_config(config, "output.yaml")
+        with patch("agent_manager.cli_extensions.config_commands.message"), pytest.raises(SystemExit):
+            ConfigCommands.export_config(config, "output.yaml")
 
 
 class TestConfigCommandsImportConfig:
@@ -447,9 +440,11 @@ class TestConfigCommandsImportConfig:
         config.exists.return_value = True
         config.config_file = tmp_path / "config.yaml"
 
-        with patch("agent_manager.cli_extensions.config_commands.message"):
-            with patch("builtins.input", return_value="no"):
-                ConfigCommands.import_config(config, str(input_file))
+        with (
+            patch("agent_manager.cli_extensions.config_commands.message"),
+            patch("builtins.input", return_value="no"),
+        ):
+            ConfigCommands.import_config(config, str(input_file))
 
         # Should not write if user says no
         config.write.assert_not_called()
@@ -458,9 +453,8 @@ class TestConfigCommandsImportConfig:
         """Test that import handles missing input file."""
         config = Mock(spec=Config)
 
-        with patch("agent_manager.cli_extensions.config_commands.message"):
-            with pytest.raises(SystemExit):
-                ConfigCommands.import_config(config, "nonexistent.yaml")
+        with patch("agent_manager.cli_extensions.config_commands.message"), pytest.raises(SystemExit):
+            ConfigCommands.import_config(config, "nonexistent.yaml")
 
     def test_import_handles_invalid_yaml(self, tmp_path):
         """Test that import handles invalid YAML."""
@@ -469,9 +463,8 @@ class TestConfigCommandsImportConfig:
 
         config = Mock(spec=Config)
 
-        with patch("agent_manager.cli_extensions.config_commands.message"):
-            with pytest.raises(SystemExit):
-                ConfigCommands.import_config(config, str(input_file))
+        with patch("agent_manager.cli_extensions.config_commands.message"), pytest.raises(SystemExit):
+            ConfigCommands.import_config(config, str(input_file))
 
     def test_import_validates_structure(self, tmp_path):
         """Test that import validates configuration structure."""
@@ -481,9 +474,8 @@ class TestConfigCommandsImportConfig:
 
         config = Mock(spec=Config)
 
-        with patch("agent_manager.cli_extensions.config_commands.message"):
-            with pytest.raises(SystemExit):
-                ConfigCommands.import_config(config, str(input_file))
+        with patch("agent_manager.cli_extensions.config_commands.message"), pytest.raises(SystemExit):
+            ConfigCommands.import_config(config, str(input_file))
 
 
 class TestConfigCommandsShowLocation:
@@ -548,9 +540,8 @@ class TestConfigCommandsEdgeCases:
         config.exists.return_value = True
         config.read.return_value = {"hierarchy": [{"name": "org", "url": "url", "repo_type": "git", "repo": Mock()}]}
 
-        with patch("agent_manager.cli_extensions.config_commands.message"):
-            with pytest.raises(SystemExit):
-                ConfigCommands.export_config(config, str(output_file))
+        with patch("agent_manager.cli_extensions.config_commands.message"), pytest.raises(SystemExit):
+            ConfigCommands.export_config(config, str(output_file))
 
     def test_import_accepts_yes_variations(self, tmp_path):
         """Test that import accepts various yes responses."""
@@ -565,9 +556,11 @@ class TestConfigCommandsEdgeCases:
         config.config_file = tmp_path / "config.yaml"
 
         for yes_response in ["yes", "y", "YES", "Y"]:
-            with patch("agent_manager.cli_extensions.config_commands.message"):
-                with patch("builtins.input", return_value=yes_response):
-                    ConfigCommands.import_config(config, str(input_file))
+            with (
+                patch("agent_manager.cli_extensions.config_commands.message"),
+                patch("builtins.input", return_value=yes_response),
+            ):
+                ConfigCommands.import_config(config, str(input_file))
 
             config.write.assert_called()
             config.write.reset_mock()

--- a/tests/cli_extensions/test_repo_commands.py
+++ b/tests/cli_extensions/test_repo_commands.py
@@ -1,6 +1,7 @@
 """Tests for cli_extensions/repo_commands.py - Repository CLI commands."""
 
-from unittest.mock import Mock
+import argparse
+from unittest.mock import Mock, patch
 
 from agent_manager.cli_extensions.repo_commands import RepoCommands
 
@@ -8,32 +9,80 @@ from agent_manager.cli_extensions.repo_commands import RepoCommands
 class TestRepoCommandsAddCliArguments:
     """Test cases for add_cli_arguments method."""
 
-    def test_adds_update_parser(self):
-        """Test that add_cli_arguments adds update parser."""
+    def test_adds_repos_and_update_parsers(self):
+        """Test that add_cli_arguments adds both repos and update parsers."""
         mock_subparsers = Mock()
         mock_parser = Mock()
         mock_subparsers.add_parser.return_value = mock_parser
 
         RepoCommands.add_cli_arguments(mock_subparsers)
 
-        mock_subparsers.add_parser.assert_called_once()
-        call_args = mock_subparsers.add_parser.call_args
-        assert call_args[0][0] == "update"
-        assert "Update all repositories" in call_args[1]["help"]
+        # Should add both "repos" and "update" parsers
+        calls = [call[0][0] for call in mock_subparsers.add_parser.call_args_list]
+        assert "repos" in calls
+        assert "update" in calls
 
     def test_adds_force_argument(self):
         """Test that update parser includes force argument."""
         mock_subparsers = Mock()
-        mock_parser = Mock()
-        mock_subparsers.add_parser.return_value = mock_parser
+        mock_repos_parser = Mock()
+        mock_update_parser = Mock()
+
+        def add_parser_side_effect(name, **kwargs):
+            if name == "repos":
+                return mock_repos_parser
+            elif name == "update":
+                return mock_update_parser
+            return Mock()
+
+        mock_subparsers.add_parser.side_effect = add_parser_side_effect
 
         RepoCommands.add_cli_arguments(mock_subparsers)
 
-        # Verify force argument was added
-        mock_parser.add_argument.assert_called_once()
-        call_args = mock_parser.add_argument.call_args
+        # Verify force argument was added to update parser
+        mock_update_parser.add_argument.assert_called_once()
+        call_args = mock_update_parser.add_argument.call_args
         assert call_args[0][0] == "--force"
         assert call_args[1]["action"] == "store_true"
+
+
+class TestRepoCommandsProcessReposCommand:
+    """Test cases for process_repos_command method."""
+
+    def test_no_subcommand_shows_usage(self):
+        """Test that no subcommand shows friendly usage message."""
+        args = Mock()
+        args.repos_command = None
+
+        messages = []
+
+        def capture_message(text, *args_inner, **kwargs):
+            messages.append(text)
+
+        with patch("agent_manager.cli_extensions.repo_commands.message", side_effect=capture_message):
+            RepoCommands.process_repos_command(args)
+
+        output = "\n".join(messages)
+        assert "Usage: agent-manager repos <command>" in output
+        assert "Available commands:" in output
+        assert "list" in output
+        assert "enable" in output
+        assert "disable" in output
+
+    def test_no_repos_command_attribute_shows_usage(self):
+        """Test that missing repos_command attribute shows friendly usage."""
+        args = Mock(spec=[])  # Mock with no attributes
+
+        messages = []
+
+        def capture_message(text, *args_inner, **kwargs):
+            messages.append(text)
+
+        with patch("agent_manager.cli_extensions.repo_commands.message", side_effect=capture_message):
+            RepoCommands.process_repos_command(args)
+
+        output = "\n".join(messages)
+        assert "Usage: agent-manager repos <command>" in output
 
 
 class TestRepoCommandsIntegration:
@@ -41,8 +90,6 @@ class TestRepoCommandsIntegration:
 
     def test_add_and_process_workflow(self):
         """Test complete workflow of adding arguments and processing."""
-        import argparse
-
         # Create parser
         parser = argparse.ArgumentParser()
         subparsers = parser.add_subparsers(dest="command")
@@ -62,8 +109,6 @@ class TestRepoCommandsIntegration:
 
     def test_full_command_flow(self):
         """Test full command flow from argparse to parsing."""
-        import argparse
-
         # Set up parser
         parser = argparse.ArgumentParser()
         subparsers = parser.add_subparsers(dest="command")

--- a/tests/core/test_agents.py
+++ b/tests/core/test_agents.py
@@ -192,4 +192,3 @@ class TestAgentPluginPrefix:
     def test_prefix_is_am_agent(self):
         """Test that the plugin prefix is 'am_agent_'."""
         assert AGENT_PLUGIN_PREFIX == "am_agent_"
-

--- a/tests/core/test_agents.py
+++ b/tests/core/test_agents.py
@@ -88,9 +88,8 @@ class TestLoadAgent:
         """Test that SystemExit is raised when agent not found."""
         mock_discover.return_value = {"claude": {"package_name": "am_agent_claude"}}
 
-        with patch("agent_manager.core.agents.message"):
-            with pytest.raises(SystemExit):
-                load_agent("nonexistent")
+        with patch("agent_manager.core.agents.message"), pytest.raises(SystemExit):
+            load_agent("nonexistent")
 
     @patch("agent_manager.core.agents.load_plugin_class")
     @patch("agent_manager.core.agents.discover_agent_plugins")
@@ -99,9 +98,8 @@ class TestLoadAgent:
         mock_discover.return_value = {"claude": {"package_name": "am_agent_claude"}}
         mock_load_class.side_effect = Exception("Load failed")
 
-        with patch("agent_manager.core.agents.message"):
-            with pytest.raises(SystemExit):
-                load_agent("claude")
+        with patch("agent_manager.core.agents.message"), pytest.raises(SystemExit):
+            load_agent("claude")
 
     @patch("agent_manager.core.agents.load_plugin_class")
     def test_uses_provided_plugins_dict(self, mock_load_class):
@@ -167,9 +165,8 @@ class TestRunAgents:
         """Test that SystemExit is raised when no agents found."""
         mock_discover.return_value = {}
 
-        with patch("agent_manager.core.agents.message"):
-            with pytest.raises(SystemExit):
-                run_agents(["all"], {})
+        with patch("agent_manager.core.agents.message"), pytest.raises(SystemExit):
+            run_agents(["all"], {})
 
     @patch("agent_manager.core.agents.load_agent")
     @patch("agent_manager.core.agents.discover_agent_plugins")
@@ -181,9 +178,8 @@ class TestRunAgents:
         mock_agent_instance.update.side_effect = Exception("Update failed")
         mock_load_agent.return_value = mock_agent_instance
 
-        with patch("agent_manager.core.agents.message"):
-            with pytest.raises(SystemExit):
-                run_agents(["claude"], {})
+        with patch("agent_manager.core.agents.message"), pytest.raises(SystemExit):
+            run_agents(["claude"], {})
 
 
 class TestAgentPluginPrefix:

--- a/tests/core/test_mergers.py
+++ b/tests/core/test_mergers.py
@@ -1,11 +1,10 @@
 """Tests for core/mergers.py - Merger discovery and factory functions."""
 
 from unittest.mock import Mock, patch
-import pytest
 
-from agent_manager.core.mergers import create_default_merger_registry, discover_merger_classes
 from agent_manager.core.merger_registry import MergerRegistry
-from agent_manager.plugins.mergers import AbstractMerger, JsonMerger, YamlMerger, MarkdownMerger, TextMerger
+from agent_manager.core.mergers import create_default_merger_registry, discover_merger_classes
+from agent_manager.plugins.mergers import AbstractMerger, JsonMerger, MarkdownMerger, TextMerger, YamlMerger
 
 
 class TestDiscoverMergerClassesImportError:
@@ -14,7 +13,6 @@ class TestDiscoverMergerClassesImportError:
     def test_discover_handles_import_error(self):
         """Test that discover_merger_classes handles ImportError gracefully."""
         from agent_manager.core import mergers
-        import agent_manager.plugins.mergers as mergers_package
 
         # Mock iter_modules to include a module that will fail to import
         with patch("pkgutil.iter_modules") as mock_iter:

--- a/tests/core/test_repos.py
+++ b/tests/core/test_repos.py
@@ -1,6 +1,5 @@
 """Tests for core/repos.py - Repository discovery and factory functions."""
 
-from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -127,7 +126,7 @@ class TestBuildRepoTypeMap:
         repo_map = build_repo_type_map()
 
         for repo_type, repo_class in repo_map.items():
-            assert repo_class.REPO_TYPE == repo_type
+            assert repo_type == repo_class.REPO_TYPE
 
 
 class TestGetRepoTypeMap:
@@ -252,9 +251,8 @@ class TestUpdateRepositories:
 
         config_data = {"hierarchy": [{"name": "org", "repo": repo}]}
 
-        with patch("agent_manager.core.repos.message"):
-            with pytest.raises(SystemExit):
-                update_repositories(config_data)
+        with patch("agent_manager.core.repos.message"), pytest.raises(SystemExit):
+            update_repositories(config_data)
 
     def test_continues_after_single_repo_error(self):
         """Test that other repos are updated even if one fails."""
@@ -272,9 +270,8 @@ class TestUpdateRepositories:
             ]
         }
 
-        with patch("agent_manager.core.repos.message"):
-            with pytest.raises(SystemExit):
-                update_repositories(config_data)
+        with patch("agent_manager.core.repos.message"), pytest.raises(SystemExit):
+            update_repositories(config_data)
 
         # repo2 should still be attempted
         repo2.update.assert_called_once()
@@ -320,12 +317,9 @@ class TestReposIntegration:
         """Test that all discovered repo types can be instantiated."""
         repo_map = get_repo_type_map()
 
-        for repo_type, repo_class in repo_map.items():
+        for repo_type, _repo_class in repo_map.items():
             # Create appropriate URL for each type
-            if repo_type == "git":
-                url = "https://github.com/test/repo"
-            else:  # file/local
-                url = "file:///tmp/test"
+            url = "https://github.com/test/repo" if repo_type == "git" else "file:///tmp/test"
 
             repo = create_repo("test", url, tmp_path, repo_type)
 
@@ -348,11 +342,8 @@ class TestReposIntegration:
 
         for repo_type, expected_class in repo_map.items():
             # Create appropriate URL
-            if repo_type == "git":
-                url = "https://github.com/test/repo"
-            else:
-                url = "file:///tmp/test"
+            url = "https://github.com/test/repo" if repo_type == "git" else "file:///tmp/test"
 
             repo = create_repo("test", url, tmp_path, repo_type)
 
-            assert type(repo) == expected_class
+            assert type(repo) is expected_class

--- a/tests/output/test_output.py
+++ b/tests/output/test_output.py
@@ -1,7 +1,5 @@
 """Tests for output/output.py - Output and logging utilities."""
 
-import sys
-
 from agent_manager.output import Color, MessageType, OutputManager, VerbosityLevel, message
 
 

--- a/tests/plugins/agents/test_agent.py
+++ b/tests/plugins/agents/test_agent.py
@@ -1,7 +1,7 @@
 """Tests for plugins/agents/agent.py - Abstract agent base class."""
 
 from pathlib import Path
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -661,14 +661,16 @@ class TestAbstractAgentExceptionHandling:
         agent.agent_directory.mkdir()
 
         # Make the merger raise an exception
-        with patch("agent_manager.plugins.agents.agent.message"):
-            with patch.object(agent.merger_registry, "get_merger") as mock_get_merger:
-                mock_merger = Mock()
-                mock_merger.merge.side_effect = ValueError("Test error")
-                mock_get_merger.return_value = mock_merger
+        with (
+            patch("agent_manager.plugins.agents.agent.message"),
+            patch.object(agent.merger_registry, "get_merger") as mock_get_merger,
+        ):
+            mock_merger = Mock()
+            mock_merger.merge.side_effect = ValueError("Test error")
+            mock_get_merger.return_value = mock_merger
 
-                # Should not raise, just log warning
-                agent.merge_configurations(config)
+            # Should not raise, just log warning
+            agent.merge_configurations(config)
 
 
 class TestAbstractAgentEdgeCases:

--- a/tests/plugins/mergers/test_abstract_merger.py
+++ b/tests/plugins/mergers/test_abstract_merger.py
@@ -103,7 +103,7 @@ class TestMergerPreferenceSchema:
         """Test that preference schemas follow expected structure."""
         prefs = TestMerger.merge_preferences()
 
-        for pref_name, pref_schema in prefs.items():
+        for _pref_name, pref_schema in prefs.items():
             # Each preference should have type
             assert "type" in pref_schema
             assert pref_schema["type"] in ["int", "str", "bool", "float"]

--- a/tests/plugins/repos/test_git_repo.py
+++ b/tests/plugins/repos/test_git_repo.py
@@ -1,7 +1,6 @@
 """Tests for plugins/repos/git_repo.py - Git repository implementation."""
 
-from pathlib import Path
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import git
 import pytest
@@ -179,9 +178,8 @@ class TestGitRepoNeedsUpdate:
         # Mock git.Repo to raise InvalidGitRepositoryError
         mock_repo_class.side_effect = git.exc.InvalidGitRepositoryError
 
-        with patch("agent_manager.plugins.repos.git_repo.message"):
-            with pytest.raises(SystemExit):
-                repo.needs_update()
+        with patch("agent_manager.plugins.repos.git_repo.message"), pytest.raises(SystemExit):
+            repo.needs_update()
 
 
 class TestGitRepoUpdate:
@@ -207,9 +205,8 @@ class TestGitRepoUpdate:
 
         mock_repo_class.clone_from.side_effect = git.exc.GitCommandError("clone", 128)
 
-        with patch("agent_manager.plugins.repos.git_repo.message"):
-            with pytest.raises(SystemExit):
-                repo.update()
+        with patch("agent_manager.plugins.repos.git_repo.message"), pytest.raises(SystemExit):
+            repo.update()
 
     @patch("agent_manager.plugins.repos.git_repo.git.Repo")
     def test_update_pulls_when_exists(self, mock_repo_class, tmp_path):
@@ -261,9 +258,8 @@ class TestGitRepoUpdate:
         mock_repo_instance.remotes.origin.pull.side_effect = git.exc.GitCommandError("pull", 1)
         mock_repo_class.return_value = mock_repo_instance
 
-        with patch("agent_manager.plugins.repos.git_repo.message"):
-            with pytest.raises(SystemExit):
-                repo.update()
+        with patch("agent_manager.plugins.repos.git_repo.message"), pytest.raises(SystemExit):
+            repo.update()
 
     @patch("agent_manager.plugins.repos.git_repo.git.Repo")
     def test_update_exits_on_invalid_repo(self, mock_repo_class, tmp_path):
@@ -274,9 +270,8 @@ class TestGitRepoUpdate:
         # Mock git.Repo to raise InvalidGitRepositoryError
         mock_repo_class.side_effect = git.exc.InvalidGitRepositoryError
 
-        with patch("agent_manager.plugins.repos.git_repo.message"):
-            with pytest.raises(SystemExit):
-                repo.update()
+        with patch("agent_manager.plugins.repos.git_repo.message"), pytest.raises(SystemExit):
+            repo.update()
 
 
 class TestGitRepoIntegration:
@@ -365,6 +360,5 @@ class TestGitRepoEdgeCases:
 
         mock_repo_class.clone_from.side_effect = Exception("Unexpected error")
 
-        with patch("agent_manager.plugins.repos.git_repo.message"):
-            with pytest.raises(SystemExit):
-                repo.update()
+        with patch("agent_manager.plugins.repos.git_repo.message"), pytest.raises(SystemExit):
+            repo.update()

--- a/tests/plugins/repos/test_local_repo.py
+++ b/tests/plugins/repos/test_local_repo.py
@@ -1,9 +1,6 @@
 """Tests for plugins/repos/local_repo.py - Local directory repository implementation."""
 
-from pathlib import Path
 from unittest.mock import patch
-
-import pytest
 
 from agent_manager.plugins.repos.local_repo import LocalRepo
 
@@ -94,7 +91,7 @@ class TestLocalRepoValidateUrl:
             tmp_path.mkdir(exist_ok=True)
 
             with patch("agent_manager.plugins.repos.local_repo.message"):
-                result = LocalRepo.validate_url("file://~/test")
+                LocalRepo.validate_url("file://~/test")
 
             assert mock_resolve.called
 

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -5,7 +5,6 @@ from unittest.mock import Mock, patch
 import pytest
 
 from agent_manager.agent_manager import main
-from agent_manager.cli_extensions import MergerCommands
 
 
 class TestCLIArgumentParsing:
@@ -32,62 +31,70 @@ class TestCLIArgumentParsing:
         ]
 
         for args, expected_level in test_cases:
-            with patch("sys.argv", ["agent-manager"] + args + ["config", "where"]):
-                with patch("agent_manager.agent_manager.Config") as mock_config:
-                    with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command"):
-                        with patch("agent_manager.agent_manager.get_output") as mock_output:
-                            mock_output_instance = Mock(verbosity=0, use_color=True)
-                            mock_output.return_value = mock_output_instance
-                            mock_config.return_value.ensure_directories = Mock()
+            with (
+                patch("sys.argv", ["agent-manager"] + args + ["config", "where"]),
+                patch("agent_manager.agent_manager.Config") as mock_config,
+                patch("agent_manager.agent_manager.ConfigCommands.process_cli_command"),
+                patch("agent_manager.agent_manager.get_output") as mock_output,
+            ):
+                mock_output_instance = Mock(verbosity=0, use_color=True)
+                mock_output.return_value = mock_output_instance
+                mock_config.return_value.ensure_directories = Mock()
 
-                            main()
+                main()
 
-                            assert mock_output_instance.verbosity == expected_level
+                assert mock_output_instance.verbosity == expected_level
 
     def test_no_color_option(self):
         """Test --no-color disables colored output."""
-        with patch("sys.argv", ["agent-manager", "--no-color", "config", "where"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command"):
-                    with patch("agent_manager.agent_manager.get_output") as mock_output:
-                        with patch("sys.stdout.isatty", return_value=True):
-                            mock_output_instance = Mock(verbosity=0, use_color=True)
-                            mock_output.return_value = mock_output_instance
-                            mock_config.return_value.ensure_directories = Mock()
+        with (
+            patch("sys.argv", ["agent-manager", "--no-color", "config", "where"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.ConfigCommands.process_cli_command"),
+            patch("agent_manager.agent_manager.get_output") as mock_output,
+            patch("sys.stdout.isatty", return_value=True),
+        ):
+            mock_output_instance = Mock(verbosity=0, use_color=True)
+            mock_output.return_value = mock_output_instance
+            mock_config.return_value.ensure_directories = Mock()
 
-                            main()
+            main()
 
-                            assert mock_output_instance.use_color is False
+            assert mock_output_instance.use_color is False
 
     def test_color_enabled_when_tty(self):
         """Test color is enabled when stdout is a TTY."""
-        with patch("sys.argv", ["agent-manager", "config", "where"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command"):
-                    with patch("agent_manager.agent_manager.get_output") as mock_output:
-                        with patch("sys.stdout.isatty", return_value=True):
-                            mock_output_instance = Mock(verbosity=0, use_color=False)
-                            mock_output.return_value = mock_output_instance
-                            mock_config.return_value.ensure_directories = Mock()
+        with (
+            patch("sys.argv", ["agent-manager", "config", "where"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.ConfigCommands.process_cli_command"),
+            patch("agent_manager.agent_manager.get_output") as mock_output,
+            patch("sys.stdout.isatty", return_value=True),
+        ):
+            mock_output_instance = Mock(verbosity=0, use_color=False)
+            mock_output.return_value = mock_output_instance
+            mock_config.return_value.ensure_directories = Mock()
 
-                            main()
+            main()
 
-                            assert mock_output_instance.use_color is True
+            assert mock_output_instance.use_color is True
 
     def test_color_disabled_when_not_tty(self):
         """Test color is disabled when stdout is not a TTY."""
-        with patch("sys.argv", ["agent-manager", "config", "where"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command"):
-                    with patch("agent_manager.agent_manager.get_output") as mock_output:
-                        with patch("sys.stdout.isatty", return_value=False):
-                            mock_output_instance = Mock(verbosity=0, use_color=True)
-                            mock_output.return_value = mock_output_instance
-                            mock_config.return_value.ensure_directories = Mock()
+        with (
+            patch("sys.argv", ["agent-manager", "config", "where"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.ConfigCommands.process_cli_command"),
+            patch("agent_manager.agent_manager.get_output") as mock_output,
+            patch("sys.stdout.isatty", return_value=False),
+        ):
+            mock_output_instance = Mock(verbosity=0, use_color=True)
+            mock_output.return_value = mock_output_instance
+            mock_config.return_value.ensure_directories = Mock()
 
-                            main()
+            main()
 
-                            assert mock_output_instance.use_color is False
+            assert mock_output_instance.use_color is False
 
 
 class TestConfigCommand:
@@ -95,77 +102,87 @@ class TestConfigCommand:
 
     def test_config_command_calls_config_commands(self):
         """Test that 'config' command routes to ConfigCommands."""
-        with patch("sys.argv", ["agent-manager", "config", "where"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command") as mock_process:
-                    with patch("agent_manager.output.get_output"):
-                        mock_config.return_value.ensure_directories = Mock()
+        with (
+            patch("sys.argv", ["agent-manager", "config", "where"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.ConfigCommands.process_cli_command") as mock_process,
+            patch("agent_manager.output.get_output"),
+        ):
+            mock_config.return_value.ensure_directories = Mock()
 
-                        main()
+            main()
 
-                        mock_process.assert_called_once()
-                        args, config = mock_process.call_args[0]
-                        assert args.command == "config"
-                        assert args.config_command == "where"
+            mock_process.assert_called_once()
+            args, config = mock_process.call_args[0]
+            assert args.command == "config"
+            assert args.config_command == "where"
 
     def test_config_init_command(self):
         """Test config init command."""
-        with patch("sys.argv", ["agent-manager", "config", "init"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command") as mock_process:
-                    with patch("agent_manager.output.get_output"):
-                        mock_config.return_value.ensure_directories = Mock()
+        with (
+            patch("sys.argv", ["agent-manager", "config", "init"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.ConfigCommands.process_cli_command") as mock_process,
+            patch("agent_manager.output.get_output"),
+        ):
+            mock_config.return_value.ensure_directories = Mock()
 
-                        main()
+            main()
 
-                        assert mock_process.called
-                        args = mock_process.call_args[0][0]
-                        assert args.config_command == "init"
+            assert mock_process.called
+            args = mock_process.call_args[0][0]
+            assert args.config_command == "init"
 
     def test_config_show_command(self):
         """Test config show command."""
-        with patch("sys.argv", ["agent-manager", "config", "show"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command") as mock_process:
-                    with patch("agent_manager.output.get_output"):
-                        mock_config.return_value.ensure_directories = Mock()
+        with (
+            patch("sys.argv", ["agent-manager", "config", "show"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.ConfigCommands.process_cli_command") as mock_process,
+            patch("agent_manager.output.get_output"),
+        ):
+            mock_config.return_value.ensure_directories = Mock()
 
-                        main()
+            main()
 
-                        assert mock_process.called
-                        args = mock_process.call_args[0][0]
-                        assert args.config_command == "show"
+            assert mock_process.called
+            args = mock_process.call_args[0][0]
+            assert args.config_command == "show"
 
     def test_config_add_command(self):
         """Test config add command with parameters."""
-        with patch("sys.argv", ["agent-manager", "config", "add", "test-level", "https://github.com/test/repo"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command") as mock_process:
-                    with patch("agent_manager.output.get_output"):
-                        mock_config.return_value.ensure_directories = Mock()
+        with (
+            patch("sys.argv", ["agent-manager", "config", "add", "test-level", "https://github.com/test/repo"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.ConfigCommands.process_cli_command") as mock_process,
+            patch("agent_manager.output.get_output"),
+        ):
+            mock_config.return_value.ensure_directories = Mock()
 
-                        main()
+            main()
 
-                        assert mock_process.called
-                        args = mock_process.call_args[0][0]
-                        assert args.config_command == "add"
-                        assert args.name == "test-level"
-                        assert args.url == "https://github.com/test/repo"
+            assert mock_process.called
+            args = mock_process.call_args[0][0]
+            assert args.config_command == "add"
+            assert args.name == "test-level"
+            assert args.url == "https://github.com/test/repo"
 
     def test_config_command_early_return(self):
         """Test that config command returns early without initializing repos."""
-        with patch("sys.argv", ["agent-manager", "config", "where"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command"):
-                    with patch("agent_manager.output.get_output"):
-                        mock_config_instance = Mock()
-                        mock_config.return_value = mock_config_instance
+        with (
+            patch("sys.argv", ["agent-manager", "config", "where"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.ConfigCommands.process_cli_command"),
+            patch("agent_manager.output.get_output"),
+        ):
+            mock_config_instance = Mock()
+            mock_config.return_value = mock_config_instance
 
-                        main()
+            main()
 
-                        # Should not call initialize or read
-                        mock_config_instance.initialize.assert_not_called()
-                        mock_config_instance.read.assert_not_called()
+            # Should not call initialize or read
+            mock_config_instance.initialize.assert_not_called()
+            mock_config_instance.read.assert_not_called()
 
 
 class TestMergersCommand:
@@ -173,53 +190,55 @@ class TestMergersCommand:
 
     def test_mergers_list_command(self):
         """Test mergers list command."""
-        with patch("sys.argv", ["agent-manager", "mergers", "list"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.create_default_merger_registry") as mock_registry:
-                    with patch(
-                        "agent_manager.cli_extensions.merger_commands.MergerCommands.process_cli_command"
-                    ) as mock_process:
-                        with patch("agent_manager.output.get_output"):
-                            mock_config.return_value.ensure_directories = Mock()
+        with (
+            patch("sys.argv", ["agent-manager", "mergers", "list"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.create_default_merger_registry") as mock_registry,
+            patch("agent_manager.cli_extensions.merger_commands.MergerCommands.process_cli_command") as mock_process,
+            patch("agent_manager.output.get_output"),
+        ):
+            mock_config.return_value.ensure_directories = Mock()
 
-                            main()
+            main()
 
-                            mock_registry.assert_called_once()
-                            mock_process.assert_called_once()
-                            args = mock_process.call_args[0][0]
-                            assert args.mergers_command == "list"
+            mock_registry.assert_called_once()
+            mock_process.assert_called_once()
+            args = mock_process.call_args[0][0]
+            assert args.mergers_command == "list"
 
     def test_mergers_show_command(self):
         """Test mergers show command."""
-        with patch("sys.argv", ["agent-manager", "mergers", "show", "JsonMerger"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.create_default_merger_registry"):
-                    with patch(
-                        "agent_manager.cli_extensions.merger_commands.MergerCommands.process_cli_command"
-                    ) as mock_process:
-                        with patch("agent_manager.output.get_output"):
-                            mock_config.return_value.ensure_directories = Mock()
+        with (
+            patch("sys.argv", ["agent-manager", "mergers", "show", "JsonMerger"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.create_default_merger_registry"),
+            patch("agent_manager.cli_extensions.merger_commands.MergerCommands.process_cli_command") as mock_process,
+            patch("agent_manager.output.get_output"),
+        ):
+            mock_config.return_value.ensure_directories = Mock()
 
-                            main()
+            main()
 
-                            args = mock_process.call_args[0][0]
-                            assert args.mergers_command == "show"
-                            assert args.name == "JsonMerger"
+            args = mock_process.call_args[0][0]
+            assert args.mergers_command == "show"
+            assert args.name == "JsonMerger"
 
     def test_mergers_command_early_return(self):
         """Test that mergers command returns early without repo operations."""
-        with patch("sys.argv", ["agent-manager", "mergers", "list"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.create_default_merger_registry"):
-                    with patch("agent_manager.cli_extensions.merger_commands.MergerCommands.process_cli_command"):
-                        with patch("agent_manager.output.get_output"):
-                            with patch("agent_manager.agent_manager.update_repositories") as mock_update:
-                                mock_config.return_value.ensure_directories = Mock()
+        with (
+            patch("sys.argv", ["agent-manager", "mergers", "list"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.create_default_merger_registry"),
+            patch("agent_manager.cli_extensions.merger_commands.MergerCommands.process_cli_command"),
+            patch("agent_manager.output.get_output"),
+            patch("agent_manager.agent_manager.update_repositories") as mock_update,
+        ):
+            mock_config.return_value.ensure_directories = Mock()
 
-                                main()
+            main()
 
-                                # Should not call update_repositories
-                                mock_update.assert_not_called()
+            # Should not call update_repositories
+            mock_update.assert_not_called()
 
 
 class TestUpdateCommand:
@@ -238,50 +257,56 @@ class TestUpdateCommand:
             ]
         }
 
-        with patch("sys.argv", ["agent-manager", "update"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.update_repositories") as mock_update:
-                    with patch("agent_manager.output.get_output"):
-                        mock_config_instance = Mock()
-                        mock_config.return_value = mock_config_instance
-                        mock_config_instance.initialize = Mock()
-                        mock_config_instance.read.return_value = mock_config_data
+        with (
+            patch("sys.argv", ["agent-manager", "update"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.update_repositories") as mock_update,
+            patch("agent_manager.output.get_output"),
+        ):
+            mock_config_instance = Mock()
+            mock_config.return_value = mock_config_instance
+            mock_config_instance.initialize = Mock()
+            mock_config_instance.read.return_value = mock_config_data
 
-                        main()
+            main()
 
-                        mock_update.assert_called_once()
-                        assert mock_update.call_args[0][0] == mock_config_data
-                        assert mock_update.call_args[1]["force"] is False
+            mock_update.assert_called_once()
+            assert mock_update.call_args[0][0] == mock_config_data
+            assert mock_update.call_args[1]["force"] is False
 
     def test_update_command_with_force_flag(self):
         """Test update command with --force flag."""
         mock_config_data = {"hierarchy": []}
 
-        with patch("sys.argv", ["agent-manager", "update", "--force"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.update_repositories") as mock_update:
-                    with patch("agent_manager.output.get_output"):
-                        mock_config_instance = Mock()
-                        mock_config.return_value = mock_config_instance
-                        mock_config_instance.read.return_value = mock_config_data
+        with (
+            patch("sys.argv", ["agent-manager", "update", "--force"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.update_repositories") as mock_update,
+            patch("agent_manager.output.get_output"),
+        ):
+            mock_config_instance = Mock()
+            mock_config.return_value = mock_config_instance
+            mock_config_instance.read.return_value = mock_config_data
 
-                        main()
+            main()
 
-                        assert mock_update.call_args[1]["force"] is True
+            assert mock_update.call_args[1]["force"] is True
 
     def test_update_command_returns_after_update(self):
         """Test that update command returns after updating repos."""
-        with patch("sys.argv", ["agent-manager", "update"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.update_repositories"):
-                    with patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent:
-                        with patch("agent_manager.output.get_output"):
-                            mock_config.return_value.read.return_value = {"hierarchy": []}
+        with (
+            patch("sys.argv", ["agent-manager", "update"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.update_repositories"),
+            patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent,
+            patch("agent_manager.output.get_output"),
+        ):
+            mock_config.return_value.read.return_value = {"hierarchy": []}
 
-                            main()
+            main()
 
-                            # Should not call agent commands
-                            mock_agent.assert_not_called()
+            # Should not call agent commands
+            mock_agent.assert_not_called()
 
 
 class TestNoCommand:
@@ -289,29 +314,33 @@ class TestNoCommand:
 
     def test_no_command_shows_help(self, capsys):
         """Test that running with no command shows help and exits cleanly."""
-        with patch("sys.argv", ["agent-manager"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.output.get_output"):
-                    mock_config.return_value.ensure_directories = Mock()
+        with (
+            patch("sys.argv", ["agent-manager"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.output.get_output"),
+        ):
+            mock_config.return_value.ensure_directories = Mock()
 
-                    main()
+            main()
 
-                    # Should show help message
-                    captured = capsys.readouterr()
-                    assert "usage:" in captured.out or "agent-manager" in captured.out
+            # Should show help message
+            captured = capsys.readouterr()
+            assert "usage:" in captured.out or "agent-manager" in captured.out
 
     def test_no_command_does_not_call_process_cli(self):
         """Test that running with no command doesn't call agent processing."""
-        with patch("sys.argv", ["agent-manager"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_process:
-                    with patch("agent_manager.output.get_output"):
-                        mock_config.return_value.ensure_directories = Mock()
+        with (
+            patch("sys.argv", ["agent-manager"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_process,
+            patch("agent_manager.output.get_output"),
+        ):
+            mock_config.return_value.ensure_directories = Mock()
 
-                        main()
+            main()
 
-                        # Should NOT call process_cli_command
-                        mock_process.assert_not_called()
+            # Should NOT call process_cli_command
+            mock_process.assert_not_called()
 
 
 class TestRunCommand:
@@ -321,53 +350,60 @@ class TestRunCommand:
         """Test explicit 'run' command routes to AgentCommands."""
         mock_config_data = {"hierarchy": []}
 
-        with patch("sys.argv", ["agent-manager", "run"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.update_repositories"):
-                    with patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent:
-                        with patch("agent_manager.agent_manager.get_output"):
-                            mock_config.return_value.read.return_value = mock_config_data
+        with (
+            patch("sys.argv", ["agent-manager", "run"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.update_repositories"),
+            patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent,
+            patch("agent_manager.agent_manager.get_output"),
+        ):
+            mock_config.return_value.read.return_value = mock_config_data
 
-                            main()
+            main()
 
-                            mock_agent.assert_called_once()
-                            args, config_data = mock_agent.call_args[0]
-                            assert args.command == "run"
-                            assert config_data == mock_config_data
+            mock_agent.assert_called_once()
+            args, config_data = mock_agent.call_args[0]
+            assert args.command == "run"
+            assert config_data == mock_config_data
 
     def test_run_command_explicit(self):
         """Test that run command must be explicitly specified."""
         mock_config_data = {"hierarchy": []}
 
-        with patch("sys.argv", ["agent-manager", "run"]), patch("agent_manager.agent_manager.Config") as mock_config:
-            with patch("agent_manager.agent_manager.update_repositories"):
-                with patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent:
-                    with patch("agent_manager.agent_manager.get_output"):
-                        mock_config_instance = Mock()
-                        mock_config.return_value = mock_config_instance
-                        mock_config_instance.read.return_value = mock_config_data
-                        # Mock initialize to avoid interactive prompts
-                        mock_config_instance.initialize = Mock()
+        with (
+            patch("sys.argv", ["agent-manager", "run"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.update_repositories"),
+            patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent,
+            patch("agent_manager.agent_manager.get_output"),
+        ):
+            mock_config_instance = Mock()
+            mock_config.return_value = mock_config_instance
+            mock_config_instance.read.return_value = mock_config_data
+            # Mock initialize to avoid interactive prompts
+            mock_config_instance.initialize = Mock()
 
-                        main()
+            main()
 
-                        mock_agent.assert_called_once()
+            mock_agent.assert_called_once()
 
     def test_run_command_with_agent_flag(self):
         """Test run command with specific agent selection."""
         mock_config_data = {"hierarchy": []}
 
-        with patch("sys.argv", ["agent-manager", "run", "--agent", "all"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.update_repositories"):
-                    with patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent:
-                        with patch("agent_manager.agent_manager.get_output"):
-                            mock_config.return_value.read.return_value = mock_config_data
+        with (
+            patch("sys.argv", ["agent-manager", "run", "--agent", "all"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.update_repositories"),
+            patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent,
+            patch("agent_manager.agent_manager.get_output"),
+        ):
+            mock_config.return_value.read.return_value = mock_config_data
 
-                            main()
+            main()
 
-                            args = mock_agent.call_args[0][0]
-                            assert args.agent == "all"
+            args = mock_agent.call_args[0][0]
+            assert args.agent == "all"
 
     def test_run_updates_repos_before_running_agents(self):
         """Test that repositories are updated before running agents."""
@@ -380,18 +416,18 @@ class TestRunCommand:
         def track_agent(*args, **kwargs):
             call_order.append("agent")
 
-        with patch("sys.argv", ["agent-manager", "run"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.update_repositories", side_effect=track_update):
-                    with patch(
-                        "agent_manager.agent_manager.AgentCommands.process_cli_command", side_effect=track_agent
-                    ):
-                        with patch("agent_manager.output.get_output"):
-                            mock_config.return_value.read.return_value = mock_config_data
+        with (
+            patch("sys.argv", ["agent-manager", "run"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.update_repositories", side_effect=track_update),
+            patch("agent_manager.agent_manager.AgentCommands.process_cli_command", side_effect=track_agent),
+            patch("agent_manager.output.get_output"),
+        ):
+            mock_config.return_value.read.return_value = mock_config_data
 
-                            main()
+            main()
 
-                            assert call_order == ["update", "agent"]
+            assert call_order == ["update", "agent"]
 
 
 class TestConfigInitialization:
@@ -399,51 +435,57 @@ class TestConfigInitialization:
 
     def test_config_directories_ensured(self):
         """Test that config directories are ensured on startup."""
-        with patch("sys.argv", ["agent-manager", "config", "where"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command"):
-                    with patch("agent_manager.output.get_output"):
-                        mock_config_instance = Mock()
-                        mock_config.return_value = mock_config_instance
+        with (
+            patch("sys.argv", ["agent-manager", "config", "where"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.ConfigCommands.process_cli_command"),
+            patch("agent_manager.output.get_output"),
+        ):
+            mock_config_instance = Mock()
+            mock_config.return_value = mock_config_instance
 
-                        main()
+            main()
 
-                        mock_config_instance.ensure_directories.assert_called_once()
+            mock_config_instance.ensure_directories.assert_called_once()
 
     def test_config_initialize_skipped_if_exists(self):
         """Test that initialization is skipped if config already exists."""
         mock_config_data = {"hierarchy": []}
 
-        with patch("sys.argv", ["agent-manager", "run"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.update_repositories"):
-                    with patch("agent_manager.agent_manager.AgentCommands.process_cli_command"):
-                        with patch("agent_manager.output.get_output"):
-                            mock_config_instance = Mock()
-                            mock_config.return_value = mock_config_instance
-                            mock_config_instance.read.return_value = mock_config_data
+        with (
+            patch("sys.argv", ["agent-manager", "run"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.update_repositories"),
+            patch("agent_manager.agent_manager.AgentCommands.process_cli_command"),
+            patch("agent_manager.output.get_output"),
+        ):
+            mock_config_instance = Mock()
+            mock_config.return_value = mock_config_instance
+            mock_config_instance.read.return_value = mock_config_data
 
-                            main()
+            main()
 
-                            # initialize should be called with skip_if_already_created=True
-                            mock_config_instance.initialize.assert_called_once_with(skip_if_already_created=True)
+            # initialize should be called with skip_if_already_created=True
+            mock_config_instance.initialize.assert_called_once_with(skip_if_already_created=True)
 
     def test_config_read_called_for_run_command(self):
         """Test that config.read() is called for run/update commands."""
         mock_config_data = {"hierarchy": []}
 
-        with patch("sys.argv", ["agent-manager", "run"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.update_repositories"):
-                    with patch("agent_manager.agent_manager.AgentCommands.process_cli_command"):
-                        with patch("agent_manager.output.get_output"):
-                            mock_config_instance = Mock()
-                            mock_config.return_value = mock_config_instance
-                            mock_config_instance.read.return_value = mock_config_data
+        with (
+            patch("sys.argv", ["agent-manager", "run"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.update_repositories"),
+            patch("agent_manager.agent_manager.AgentCommands.process_cli_command"),
+            patch("agent_manager.output.get_output"),
+        ):
+            mock_config_instance = Mock()
+            mock_config.return_value = mock_config_instance
+            mock_config_instance.read.return_value = mock_config_data
 
-                            main()
+            main()
 
-                            mock_config_instance.read.assert_called_once()
+            mock_config_instance.read.assert_called_once()
 
 
 class TestErrorHandling:
@@ -451,30 +493,34 @@ class TestErrorHandling:
 
     def test_unknown_command_shows_help(self, capsys):
         """Test that unknown commands display help and exit."""
-        with patch("sys.argv", ["agent-manager", "unknown-command"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.update_repositories"):
-                    with patch("agent_manager.agent_manager.get_output"):
-                        mock_config.return_value.read.return_value = {"hierarchy": []}
+        with (
+            patch("sys.argv", ["agent-manager", "unknown-command"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.update_repositories"),
+            patch("agent_manager.agent_manager.get_output"),
+        ):
+            mock_config.return_value.read.return_value = {"hierarchy": []}
 
-                        with pytest.raises(SystemExit) as exc_info:
-                            main()
+            with pytest.raises(SystemExit) as exc_info:
+                main()
 
-                        assert exc_info.value.code == 2  # argparse returns 2 for invalid arguments
+            assert exc_info.value.code == 2  # argparse returns 2 for invalid arguments
 
     def test_config_read_failure_propagates(self):
         """Test that config read failures propagate correctly."""
-        with patch("sys.argv", ["agent-manager", "run"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.output.get_output"):
-                    mock_config_instance = Mock()
-                    mock_config.return_value = mock_config_instance
-                    mock_config_instance.read.side_effect = SystemExit(1)
+        with (
+            patch("sys.argv", ["agent-manager", "run"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.output.get_output"),
+        ):
+            mock_config_instance = Mock()
+            mock_config.return_value = mock_config_instance
+            mock_config_instance.read.side_effect = SystemExit(1)
 
-                    with pytest.raises(SystemExit) as exc_info:
-                        main()
+            with pytest.raises(SystemExit) as exc_info:
+                main()
 
-                    assert exc_info.value.code == 1
+            assert exc_info.value.code == 1
 
 
 class TestIntegration:
@@ -499,80 +545,84 @@ class TestIntegration:
             ]
         }
 
-        with patch("sys.argv", ["agent-manager", "-vv", "run", "--agent", "all"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.update_repositories") as mock_update:
-                    with patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent:
-                        with patch("agent_manager.agent_manager.get_output") as mock_output:
-                            mock_output_instance = Mock(verbosity=0, use_color=True)
-                            mock_output.return_value = mock_output_instance
+        with (
+            patch("sys.argv", ["agent-manager", "-vv", "run", "--agent", "all"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.update_repositories") as mock_update,
+            patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent,
+            patch("agent_manager.agent_manager.get_output") as mock_output,
+        ):
+            mock_output_instance = Mock(verbosity=0, use_color=True)
+            mock_output.return_value = mock_output_instance
 
-                            mock_config_instance = Mock()
-                            mock_config.return_value = mock_config_instance
-                            mock_config_instance.read.return_value = mock_config_data
+            mock_config_instance = Mock()
+            mock_config.return_value = mock_config_instance
+            mock_config_instance.read.return_value = mock_config_data
 
-                            main()
+            main()
 
-                            # Verify full workflow
-                            assert mock_output_instance.verbosity == 2
-                            mock_config_instance.ensure_directories.assert_called_once()
-                            mock_config_instance.initialize.assert_called_once_with(skip_if_already_created=True)
-                            mock_config_instance.read.assert_called_once()
-                            mock_update.assert_called_once_with(mock_config_data, force=False)
-                            mock_agent.assert_called_once()
+            # Verify full workflow
+            assert mock_output_instance.verbosity == 2
+            mock_config_instance.ensure_directories.assert_called_once()
+            mock_config_instance.initialize.assert_called_once_with(skip_if_already_created=True)
+            mock_config_instance.read.assert_called_once()
+            mock_update.assert_called_once_with(mock_config_data, force=False)
+            mock_agent.assert_called_once()
 
-                        # Verify agent command args
-                        args, config_data = mock_agent.call_args[0]
-                        assert args.command == "run"
-                        assert args.agent == "all"
-                        assert config_data == mock_config_data
+            # Verify agent command args
+            args, config_data = mock_agent.call_args[0]
+            assert args.command == "run"
+            assert args.agent == "all"
+            assert config_data == mock_config_data
 
     def test_config_command_workflow(self):
         """Test complete config management workflow."""
-        with patch("sys.argv", ["agent-manager", "-v", "config", "add", "team", "https://github.com/test/team"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command") as mock_process:
-                    with patch("agent_manager.agent_manager.get_output") as mock_output:
-                        mock_output_instance = Mock(verbosity=0, use_color=True)
-                        mock_output.return_value = mock_output_instance
+        with (
+            patch("sys.argv", ["agent-manager", "-v", "config", "add", "team", "https://github.com/test/team"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.ConfigCommands.process_cli_command") as mock_process,
+            patch("agent_manager.agent_manager.get_output") as mock_output,
+        ):
+            mock_output_instance = Mock(verbosity=0, use_color=True)
+            mock_output.return_value = mock_output_instance
 
-                        mock_config_instance = Mock()
-                        mock_config.return_value = mock_config_instance
+            mock_config_instance = Mock()
+            mock_config.return_value = mock_config_instance
 
-                        main()
+            main()
 
-                        # Verify workflow
-                        assert mock_output_instance.verbosity == 1
-                        mock_config_instance.ensure_directories.assert_called_once()
-                        mock_process.assert_called_once()
+            # Verify workflow
+            assert mock_output_instance.verbosity == 1
+            mock_config_instance.ensure_directories.assert_called_once()
+            mock_process.assert_called_once()
 
-                        # Verify no repo operations
-                        mock_config_instance.initialize.assert_not_called()
-                        mock_config_instance.read.assert_not_called()
+            # Verify no repo operations
+            mock_config_instance.initialize.assert_not_called()
+            mock_config_instance.read.assert_not_called()
 
     def test_mergers_configuration_workflow(self):
         """Test complete mergers configuration workflow."""
-        with patch("sys.argv", ["agent-manager", "mergers", "configure", "--merger", "JsonMerger"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.create_default_merger_registry") as mock_registry:
-                    with patch(
-                        "agent_manager.cli_extensions.merger_commands.MergerCommands.process_cli_command"
-                    ) as mock_process:
-                        with patch("agent_manager.output.get_output"):
-                            mock_config_instance = Mock()
-                            mock_config.return_value = mock_config_instance
+        with (
+            patch("sys.argv", ["agent-manager", "mergers", "configure", "--merger", "JsonMerger"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.create_default_merger_registry") as mock_registry,
+            patch("agent_manager.cli_extensions.merger_commands.MergerCommands.process_cli_command") as mock_process,
+            patch("agent_manager.output.get_output"),
+        ):
+            mock_config_instance = Mock()
+            mock_config.return_value = mock_config_instance
 
-                            main()
+            main()
 
-                            # Verify workflow
-                            mock_config_instance.ensure_directories.assert_called_once()
-                            mock_registry.assert_called_once()
-                            mock_process.assert_called_once()
+            # Verify workflow
+            mock_config_instance.ensure_directories.assert_called_once()
+            mock_registry.assert_called_once()
+            mock_process.assert_called_once()
 
-                            # Verify args
-                            args = mock_process.call_args[0][0]
-                            assert args.mergers_command == "configure"
-                            assert args.merger == "JsonMerger"
+            # Verify args
+            args = mock_process.call_args[0][0]
+            assert args.mergers_command == "configure"
+            assert args.merger == "JsonMerger"
 
 
 class TestFullIntegration:
@@ -625,8 +675,6 @@ class TestFullIntegration:
     def test_full_merge_integration(self, mock_config_data, temp_output_dir, test_data_path):
         """Test full integration: read config, merge files, write to TestAgent."""
         import json
-        import tempfile
-        from pathlib import Path
 
         import yaml
 
@@ -688,28 +736,29 @@ class TestFullIntegration:
 
     def test_run_command_flow(self, mock_config_data, temp_output_dir):
         """Test the run command flow through the CLI."""
-        from pathlib import Path
 
-        with patch("sys.argv", ["agent-manager", "run"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent_cmd:
-                    with patch("agent_manager.agent_manager.update_repositories") as mock_update:
-                        # Setup mocks
-                        mock_config_instance = Mock()
-                        mock_config.return_value = mock_config_instance
-                        mock_config_instance.ensure_directories = Mock()
-                        mock_config_instance.initialize = Mock()
-                        mock_config_instance.read.return_value = mock_config_data
+        with (
+            patch("sys.argv", ["agent-manager", "run"]),
+            patch("agent_manager.agent_manager.Config") as mock_config,
+            patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent_cmd,
+            patch("agent_manager.agent_manager.update_repositories") as mock_update,
+        ):
+            # Setup mocks
+            mock_config_instance = Mock()
+            mock_config.return_value = mock_config_instance
+            mock_config_instance.ensure_directories = Mock()
+            mock_config_instance.initialize = Mock()
+            mock_config_instance.read.return_value = mock_config_data
 
-                        # Run main
-                        main()
+            # Run main
+            main()
 
-                        # Verify the flow
-                        mock_config_instance.ensure_directories.assert_called_once()
-                        mock_config_instance.initialize.assert_called_once_with(skip_if_already_created=True)
-                        mock_config_instance.read.assert_called_once()
-                        mock_update.assert_called_once()
-                        mock_agent_cmd.assert_called_once()
+            # Verify the flow
+            mock_config_instance.ensure_directories.assert_called_once()
+            mock_config_instance.initialize.assert_called_once_with(skip_if_already_created=True)
+            mock_config_instance.read.assert_called_once()
+            mock_update.assert_called_once()
+            mock_agent_cmd.assert_called_once()
 
     def test_agent_import(self):
         """Test that TestAgent can be imported and instantiated."""

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -204,7 +204,7 @@ class TestMergersCommand:
 
                             args = mock_process.call_args[0][0]
                             assert args.mergers_command == "show"
-                            assert args.merger == "JsonMerger"
+                            assert args.name == "JsonMerger"
 
     def test_mergers_command_early_return(self):
         """Test that mergers command returns early without repo operations."""

--- a/tests/utils/test_discovery.py
+++ b/tests/utils/test_discovery.py
@@ -93,6 +93,7 @@ class TestDiscoverByEntryPoints:
     @patch("agent_manager.utils.discovery.importlib.metadata.entry_points")
     def test_discovers_via_entry_points(self, mock_entry_points):
         """Test discovery via entry points."""
+
         # Create a real class hierarchy for issubclass check
         class BaseClass:
             pass
@@ -261,7 +262,7 @@ class TestGetDisabledPlugins:
                         "mergers": ["smart_markdown"],
                         "agents": ["claude"],
                     }
-                }
+                },
             }
             with open(config_file, "w") as f:
                 yaml.dump(config, f)
@@ -410,4 +411,3 @@ class TestFilterDisabledPlugins:
             result = filter_disabled_plugins(plugins, "mergers", config_file)
 
             assert len(result) == 2
-

--- a/tests/utils/test_discovery.py
+++ b/tests/utils/test_discovery.py
@@ -8,14 +8,14 @@ import pytest
 import yaml
 
 from agent_manager.utils.discovery import (
+    _discover_by_entry_points,
+    _discover_by_package_prefix,
     discover_external_plugins,
     filter_disabled_plugins,
     get_disabled_plugins,
     is_plugin_disabled,
     load_plugin_class,
     set_plugin_enabled,
-    _discover_by_package_prefix,
-    _discover_by_entry_points,
 )
 
 


### PR DESCRIPTION
## Summary

- **Align CLI usage messages**: `agents`, `repos`, and `mergers` now show the same friendly `Usage:` / `Available commands:` format as `config` when run without a subcommand, instead of printing an error and exiting with code 1.
- **Standardize help text**: align descriptions across plugin groups (`mergers list`, `repos enable/disable`, `mergers show` positional arg renamed from `merger` to `name`).
- **Add human-readable descriptions** to all 23 commands and subcommands so that `--help` explains what each command does, not just its usage syntax.

## Test plan

- [x] All 84 `tests/cli_extensions/` tests pass
- [x] Full suite: 581 passed, 13 failed (all 13 pre-existing in `test_agent_manager.py`)
- [x] Smoke tested `agent-manager agents`, `repos`, `mergers`, `config` without subcommand
- [x] Verified `--help` output for every command and subcommand


Made with [Cursor](https://cursor.com)