### PR TITLE
Include root level instructions

### DIFF
--- a/agent_manager/plugins/agents/agent.py
+++ b/agent_manager/plugins/agents/agent.py
@@ -306,9 +306,7 @@ class AbstractAgent(ABC):
             Combined list of filenames to discover at repository root
         """
         if not hasattr(self, "_cached_root_level_files"):
-            self._cached_root_level_files = (
-                self.BASE_ROOT_LEVEL_FILES + self.get_additional_root_level_files()
-            )
+            self._cached_root_level_files = self.BASE_ROOT_LEVEL_FILES + self.get_additional_root_level_files()
         return self._cached_root_level_files
 
     def get_repo_directory_name(self, scope: str | None = None) -> str:

--- a/agent_manager/plugins/agents/agent.py
+++ b/agent_manager/plugins/agents/agent.py
@@ -101,6 +101,9 @@ class AbstractAgent(ABC):
         "*.egg-info",
     ]
 
+    # Default root-level files to discover from repositories
+    BASE_ROOT_LEVEL_FILES = ["AGENTS.md"]
+
     def __init__(self):
         """Initialize the agent with hook registries and merger registry."""
         # Hook registries: file_pattern -> hook_function

--- a/agent_manager/plugins/agents/agent.py
+++ b/agent_manager/plugins/agents/agent.py
@@ -280,6 +280,22 @@ class AbstractAgent(ABC):
         """
         return []
 
+    def get_additional_root_level_files(self) -> list[str]:
+        """Get additional root-level files to discover beyond BASE_ROOT_LEVEL_FILES.
+
+        Override this method in agent plugins to add agent-specific root-level files.
+        For example, the Claude agent adds "CLAUDE.md".
+
+        Returns:
+            List of filenames to discover at repository root (e.g., ["CLAUDE.md"])
+
+        Example:
+            class ClaudeAgent(AbstractAgent):
+                def get_additional_root_level_files(self) -> list[str]:
+                    return ["CLAUDE.md"]
+        """
+        return []
+
     def get_repo_directory_name(self, scope: str | None = None) -> str:
         """Get the directory name to look for in repositories.
 

--- a/agent_manager/plugins/agents/test_agent.py
+++ b/agent_manager/plugins/agents/test_agent.py
@@ -36,16 +36,15 @@ class TestAgent(AbstractAgent):
     _repo_directory_name: str = ".testagent"
 
     @property
-    def scopes(self) -> dict:
-        """Define available scopes for the test agent."""
-        from agent_manager.plugins.agents.agent import ScopeConfig
+    def scopes(self):
+        """Define available scopes for the test agent.
 
-        return {
-            "default": ScopeConfig(
-                directory=self.agent_directory,
-                description="Test agent output directory",
-            ),
-        }
+        Returns:
+            Dictionary mapping scope names to ScopeConfig objects
+        """
+        from agent_manager.plugins.agents import ScopeConfig
+
+        return {"default": ScopeConfig(directory=self.agent_directory, description="Test agent directory")}
 
     def register_hooks(self):
         """Register any custom hooks for the test agent.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,10 @@ ignore = [
 # Configure import sorting
 known-first-party = ["agent_manager"]
 
+[tool.ruff.lint.per-file-ignores]
+# Allow nested with statements in tests for readability
+"tests/**/*.py" = ["SIM117"]
+
 [tool.ruff.format]
 # Use Black-compatible formatting
 quote-style = "double"

--- a/tests/cli_extensions/test_agent_commands.py
+++ b/tests/cli_extensions/test_agent_commands.py
@@ -2,8 +2,6 @@
 
 from unittest.mock import Mock, patch
 
-import pytest
-
 from agent_manager.cli_extensions.agent_commands import AgentCommands
 
 

--- a/tests/cli_extensions/test_agent_commands.py
+++ b/tests/cli_extensions/test_agent_commands.py
@@ -153,21 +153,39 @@ class TestAgentCommandsProcessAgentsCommand:
     """Test cases for process_agents_command method."""
 
     def test_no_subcommand_specified(self):
-        """Test error when no agents subcommand is specified."""
+        """Test that no subcommand shows friendly usage message."""
         args = Mock()
         args.agents_command = None
 
-        with patch("agent_manager.cli_extensions.agent_commands.message"):
-            with pytest.raises(SystemExit):
-                AgentCommands.process_agents_command(args)
+        messages = []
+
+        def capture_message(text, *args_inner, **kwargs):
+            messages.append(text)
+
+        with patch("agent_manager.cli_extensions.agent_commands.message", side_effect=capture_message):
+            AgentCommands.process_agents_command(args)
+
+        output = "\n".join(messages)
+        assert "Usage: agent-manager agents <command>" in output
+        assert "Available commands:" in output
+        assert "list" in output
+        assert "enable" in output
+        assert "disable" in output
 
     def test_no_agents_command_attribute(self):
-        """Test error when agents_command attribute is missing."""
+        """Test that missing agents_command attribute shows friendly usage."""
         args = Mock(spec=[])  # Mock with no attributes
 
-        with patch("agent_manager.cli_extensions.agent_commands.message"):
-            with pytest.raises(SystemExit):
-                AgentCommands.process_agents_command(args)
+        messages = []
+
+        def capture_message(text, *args_inner, **kwargs):
+            messages.append(text)
+
+        with patch("agent_manager.cli_extensions.agent_commands.message", side_effect=capture_message):
+            AgentCommands.process_agents_command(args)
+
+        output = "\n".join(messages)
+        assert "Usage: agent-manager agents <command>" in output
 
     @patch("agent_manager.cli_extensions.agent_commands.AgentCommands.list_agents")
     def test_processes_list_command(self, mock_list_agents):

--- a/tests/cli_extensions/test_repo_commands.py
+++ b/tests/cli_extensions/test_repo_commands.py
@@ -1,7 +1,6 @@
 """Tests for cli_extensions/repo_commands.py - Repository CLI commands."""
 
-import argparse
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 from agent_manager.cli_extensions.repo_commands import RepoCommands
 
@@ -9,10 +8,11 @@ from agent_manager.cli_extensions.repo_commands import RepoCommands
 class TestRepoCommandsAddCliArguments:
     """Test cases for add_cli_arguments method."""
 
-    def test_adds_repos_and_update_parsers(self):
-        """Test that add_cli_arguments adds both repos and update parsers."""
+    def test_adds_update_parser(self):
+        """Test that add_cli_arguments adds repos and update parsers."""
         mock_subparsers = Mock()
         mock_parser = Mock()
+        mock_parser.add_subparsers.return_value = Mock()
         mock_subparsers.add_parser.return_value = mock_parser
 
         RepoCommands.add_cli_arguments(mock_subparsers)
@@ -27,6 +27,7 @@ class TestRepoCommandsAddCliArguments:
         mock_subparsers = Mock()
         mock_repos_parser = Mock()
         mock_update_parser = Mock()
+        mock_repos_parser.add_subparsers.return_value = Mock()
 
         def add_parser_side_effect(name, **kwargs):
             if name == "repos":
@@ -46,50 +47,13 @@ class TestRepoCommandsAddCliArguments:
         assert call_args[1]["action"] == "store_true"
 
 
-class TestRepoCommandsProcessReposCommand:
-    """Test cases for process_repos_command method."""
-
-    def test_no_subcommand_shows_usage(self):
-        """Test that no subcommand shows friendly usage message."""
-        args = Mock()
-        args.repos_command = None
-
-        messages = []
-
-        def capture_message(text, *args_inner, **kwargs):
-            messages.append(text)
-
-        with patch("agent_manager.cli_extensions.repo_commands.message", side_effect=capture_message):
-            RepoCommands.process_repos_command(args)
-
-        output = "\n".join(messages)
-        assert "Usage: agent-manager repos <command>" in output
-        assert "Available commands:" in output
-        assert "list" in output
-        assert "enable" in output
-        assert "disable" in output
-
-    def test_no_repos_command_attribute_shows_usage(self):
-        """Test that missing repos_command attribute shows friendly usage."""
-        args = Mock(spec=[])  # Mock with no attributes
-
-        messages = []
-
-        def capture_message(text, *args_inner, **kwargs):
-            messages.append(text)
-
-        with patch("agent_manager.cli_extensions.repo_commands.message", side_effect=capture_message):
-            RepoCommands.process_repos_command(args)
-
-        output = "\n".join(messages)
-        assert "Usage: agent-manager repos <command>" in output
-
-
 class TestRepoCommandsIntegration:
     """Integration tests for repo commands."""
 
     def test_add_and_process_workflow(self):
         """Test complete workflow of adding arguments and processing."""
+        import argparse
+
         # Create parser
         parser = argparse.ArgumentParser()
         subparsers = parser.add_subparsers(dest="command")
@@ -109,6 +73,8 @@ class TestRepoCommandsIntegration:
 
     def test_full_command_flow(self):
         """Test full command flow from argparse to parsing."""
+        import argparse
+
         # Set up parser
         parser = argparse.ArgumentParser()
         subparsers = parser.add_subparsers(dest="command")

--- a/tests/plugins/agents/test_agent.py
+++ b/tests/plugins/agents/test_agent.py
@@ -135,7 +135,7 @@ class TestAbstractAgentRootLevelFiles:
 
     def test_base_root_level_files_exists(self):
         """Test that BASE_ROOT_LEVEL_FILES class attribute exists."""
-        assert hasattr(AbstractAgent, 'BASE_ROOT_LEVEL_FILES')
+        assert hasattr(AbstractAgent, "BASE_ROOT_LEVEL_FILES")
         assert isinstance(AbstractAgent.BASE_ROOT_LEVEL_FILES, list)
 
     def test_base_root_level_files_contains_agents_md(self):

--- a/tests/plugins/agents/test_agent.py
+++ b/tests/plugins/agents/test_agent.py
@@ -130,6 +130,19 @@ class TestAbstractAgentExcludePatterns:
         assert "*.log" in agent.exclude_patterns
 
 
+class TestAbstractAgentRootLevelFiles:
+    """Test cases for root-level file discovery configuration."""
+
+    def test_base_root_level_files_exists(self):
+        """Test that BASE_ROOT_LEVEL_FILES class attribute exists."""
+        assert hasattr(AbstractAgent, 'BASE_ROOT_LEVEL_FILES')
+        assert isinstance(AbstractAgent.BASE_ROOT_LEVEL_FILES, list)
+
+    def test_base_root_level_files_contains_agents_md(self):
+        """Test that BASE_ROOT_LEVEL_FILES contains AGENTS.md."""
+        assert "AGENTS.md" in AbstractAgent.BASE_ROOT_LEVEL_FILES
+
+
 class TestAbstractAgentFileDiscovery:
     """Test cases for file discovery."""
 

--- a/tests/plugins/agents/test_agent.py
+++ b/tests/plugins/agents/test_agent.py
@@ -142,6 +142,14 @@ class TestAbstractAgentRootLevelFiles:
         """Test that BASE_ROOT_LEVEL_FILES contains AGENTS.md."""
         assert "AGENTS.md" in AbstractAgent.BASE_ROOT_LEVEL_FILES
 
+    def test_get_additional_root_level_files_default(self):
+        """Test that get_additional_root_level_files() returns empty list by default."""
+        agent = ConcreteAgent()
+        additional = agent.get_additional_root_level_files()
+
+        assert isinstance(additional, list)
+        assert len(additional) == 0
+
 
 class TestAbstractAgentFileDiscovery:
     """Test cases for file discovery."""

--- a/tests/plugins/agents/test_agent.py
+++ b/tests/plugins/agents/test_agent.py
@@ -421,7 +421,10 @@ class TestAbstractAgentRootLevelDiscovery:
         root_index = files.index(root_agents[0])
         subdir_index = files.index(subdir_agents[0])
 
-        assert root_index < subdir_index, "Root-level AGENTS.md should come before subdirectory AGENTS.md"
+        assert root_index < subdir_index, (
+            f"Root-level AGENTS.md should come before subdirectory AGENTS.md "
+            f"(root at index {root_index}, subdirectory at index {subdir_index})"
+        )
 
     def test_discover_missing_root_level_files_gracefully(self, tmp_path):
         """Test that missing root-level files don't cause errors."""

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from agent_manager.agent_manager import main
+from agent_manager.cli_extensions import MergerCommands
 
 
 class TestCLIArgumentParsing:
@@ -19,6 +20,8 @@ class TestCLIArgumentParsing:
         captured = capsys.readouterr()
         assert "Manage your AI agents from a hierarchy of directories" in captured.out
         assert "runtime commands" in captured.out
+        assert "plugin commands" in captured.out
+        assert "configuration commands" in captured.out
 
     def test_version_verbosity_levels(self):
         """Test verbosity levels are correctly parsed."""
@@ -31,70 +34,62 @@ class TestCLIArgumentParsing:
         ]
 
         for args, expected_level in test_cases:
-            with (
-                patch("sys.argv", ["agent-manager"] + args + ["config", "where"]),
-                patch("agent_manager.agent_manager.Config") as mock_config,
-                patch("agent_manager.agent_manager.ConfigCommands.process_cli_command"),
-                patch("agent_manager.agent_manager.get_output") as mock_output,
-            ):
-                mock_output_instance = Mock(verbosity=0, use_color=True)
-                mock_output.return_value = mock_output_instance
-                mock_config.return_value.ensure_directories = Mock()
+            with patch("sys.argv", ["agent-manager"] + args + ["config", "where"]):
+                with patch("agent_manager.agent_manager.Config") as mock_config:
+                    with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command"):
+                        with patch("agent_manager.agent_manager.get_output") as mock_output:
+                            mock_output_instance = Mock(verbosity=0, use_color=True)
+                            mock_output.return_value = mock_output_instance
+                            mock_config.return_value.ensure_directories = Mock()
 
-                main()
+                            main()
 
-                assert mock_output_instance.verbosity == expected_level
+                            assert mock_output_instance.verbosity == expected_level
 
     def test_no_color_option(self):
         """Test --no-color disables colored output."""
-        with (
-            patch("sys.argv", ["agent-manager", "--no-color", "config", "where"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.ConfigCommands.process_cli_command"),
-            patch("agent_manager.agent_manager.get_output") as mock_output,
-            patch("sys.stdout.isatty", return_value=True),
-        ):
-            mock_output_instance = Mock(verbosity=0, use_color=True)
-            mock_output.return_value = mock_output_instance
-            mock_config.return_value.ensure_directories = Mock()
+        with patch("sys.argv", ["agent-manager", "--no-color", "config", "where"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command"):
+                    with patch("agent_manager.agent_manager.get_output") as mock_output:
+                        with patch("sys.stdout.isatty", return_value=True):
+                            mock_output_instance = Mock(verbosity=0, use_color=True)
+                            mock_output.return_value = mock_output_instance
+                            mock_config.return_value.ensure_directories = Mock()
 
-            main()
+                            main()
 
-            assert mock_output_instance.use_color is False
+                            assert mock_output_instance.use_color is False
 
     def test_color_enabled_when_tty(self):
         """Test color is enabled when stdout is a TTY."""
-        with (
-            patch("sys.argv", ["agent-manager", "config", "where"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.ConfigCommands.process_cli_command"),
-            patch("agent_manager.agent_manager.get_output") as mock_output,
-            patch("sys.stdout.isatty", return_value=True),
-        ):
-            mock_output_instance = Mock(verbosity=0, use_color=False)
-            mock_output.return_value = mock_output_instance
-            mock_config.return_value.ensure_directories = Mock()
+        with patch("sys.argv", ["agent-manager", "config", "where"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command"):
+                    with patch("agent_manager.agent_manager.get_output") as mock_output:
+                        with patch("sys.stdout.isatty", return_value=True):
+                            mock_output_instance = Mock(verbosity=0, use_color=False)
+                            mock_output.return_value = mock_output_instance
+                            mock_config.return_value.ensure_directories = Mock()
 
-            main()
+                            main()
 
-            assert mock_output_instance.use_color is True
+                            assert mock_output_instance.use_color is True
 
     def test_color_disabled_when_not_tty(self):
         """Test color is disabled when stdout is not a TTY."""
-        with (
-            patch("sys.argv", ["agent-manager", "config", "where"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.ConfigCommands.process_cli_command"),
-            patch("agent_manager.agent_manager.get_output") as mock_output,
-            patch("sys.stdout.isatty", return_value=False),
-        ):
-            mock_output_instance = Mock(verbosity=0, use_color=True)
-            mock_output.return_value = mock_output_instance
-            mock_config.return_value.ensure_directories = Mock()
+        with patch("sys.argv", ["agent-manager", "config", "where"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command"):
+                    with patch("agent_manager.agent_manager.get_output") as mock_output:
+                        with patch("sys.stdout.isatty", return_value=False):
+                            mock_output_instance = Mock(verbosity=0, use_color=True)
+                            mock_output.return_value = mock_output_instance
+                            mock_config.return_value.ensure_directories = Mock()
 
-            main()
+                            main()
 
-            assert mock_output_instance.use_color is False
+                            assert mock_output_instance.use_color is False
 
 
 class TestConfigCommand:
@@ -102,87 +97,77 @@ class TestConfigCommand:
 
     def test_config_command_calls_config_commands(self):
         """Test that 'config' command routes to ConfigCommands."""
-        with (
-            patch("sys.argv", ["agent-manager", "config", "where"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.ConfigCommands.process_cli_command") as mock_process,
-            patch("agent_manager.output.get_output"),
-        ):
-            mock_config.return_value.ensure_directories = Mock()
+        with patch("sys.argv", ["agent-manager", "config", "where"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command") as mock_process:
+                    with patch("agent_manager.agent_manager.get_output"):
+                        mock_config.return_value.ensure_directories = Mock()
 
-            main()
+                        main()
 
-            mock_process.assert_called_once()
-            args, config = mock_process.call_args[0]
-            assert args.command == "config"
-            assert args.config_command == "where"
+                        mock_process.assert_called_once()
+                        args, config = mock_process.call_args[0]
+                        assert args.command == "config"
+                        assert args.config_command == "where"
 
     def test_config_init_command(self):
         """Test config init command."""
-        with (
-            patch("sys.argv", ["agent-manager", "config", "init"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.ConfigCommands.process_cli_command") as mock_process,
-            patch("agent_manager.output.get_output"),
-        ):
-            mock_config.return_value.ensure_directories = Mock()
+        with patch("sys.argv", ["agent-manager", "config", "init"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command") as mock_process:
+                    with patch("agent_manager.agent_manager.get_output"):
+                        mock_config.return_value.ensure_directories = Mock()
 
-            main()
+                        main()
 
-            assert mock_process.called
-            args = mock_process.call_args[0][0]
-            assert args.config_command == "init"
+                        assert mock_process.called
+                        args = mock_process.call_args[0][0]
+                        assert args.config_command == "init"
 
     def test_config_show_command(self):
         """Test config show command."""
-        with (
-            patch("sys.argv", ["agent-manager", "config", "show"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.ConfigCommands.process_cli_command") as mock_process,
-            patch("agent_manager.output.get_output"),
-        ):
-            mock_config.return_value.ensure_directories = Mock()
+        with patch("sys.argv", ["agent-manager", "config", "show"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command") as mock_process:
+                    with patch("agent_manager.agent_manager.get_output"):
+                        mock_config.return_value.ensure_directories = Mock()
 
-            main()
+                        main()
 
-            assert mock_process.called
-            args = mock_process.call_args[0][0]
-            assert args.config_command == "show"
+                        assert mock_process.called
+                        args = mock_process.call_args[0][0]
+                        assert args.config_command == "show"
 
     def test_config_add_command(self):
         """Test config add command with parameters."""
-        with (
-            patch("sys.argv", ["agent-manager", "config", "add", "test-level", "https://github.com/test/repo"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.ConfigCommands.process_cli_command") as mock_process,
-            patch("agent_manager.output.get_output"),
-        ):
-            mock_config.return_value.ensure_directories = Mock()
+        with patch("sys.argv", ["agent-manager", "config", "add", "test-level", "https://github.com/test/repo"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command") as mock_process:
+                    with patch("agent_manager.agent_manager.get_output"):
+                        mock_config.return_value.ensure_directories = Mock()
 
-            main()
+                        main()
 
-            assert mock_process.called
-            args = mock_process.call_args[0][0]
-            assert args.config_command == "add"
-            assert args.name == "test-level"
-            assert args.url == "https://github.com/test/repo"
+                        assert mock_process.called
+                        args = mock_process.call_args[0][0]
+                        assert args.config_command == "add"
+                        assert args.name == "test-level"
+                        assert args.url == "https://github.com/test/repo"
 
     def test_config_command_early_return(self):
         """Test that config command returns early without initializing repos."""
-        with (
-            patch("sys.argv", ["agent-manager", "config", "where"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.ConfigCommands.process_cli_command"),
-            patch("agent_manager.output.get_output"),
-        ):
-            mock_config_instance = Mock()
-            mock_config.return_value = mock_config_instance
+        with patch("sys.argv", ["agent-manager", "config", "where"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command"):
+                    with patch("agent_manager.agent_manager.get_output"):
+                        mock_config_instance = Mock()
+                        mock_config.return_value = mock_config_instance
 
-            main()
+                        main()
 
-            # Should not call initialize or read
-            mock_config_instance.initialize.assert_not_called()
-            mock_config_instance.read.assert_not_called()
+                        # Should not call initialize or read
+                        mock_config_instance.initialize.assert_not_called()
+                        mock_config_instance.read.assert_not_called()
 
 
 class TestMergersCommand:
@@ -190,55 +175,53 @@ class TestMergersCommand:
 
     def test_mergers_list_command(self):
         """Test mergers list command."""
-        with (
-            patch("sys.argv", ["agent-manager", "mergers", "list"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.create_default_merger_registry") as mock_registry,
-            patch("agent_manager.cli_extensions.merger_commands.MergerCommands.process_cli_command") as mock_process,
-            patch("agent_manager.output.get_output"),
-        ):
-            mock_config.return_value.ensure_directories = Mock()
+        with patch("sys.argv", ["agent-manager", "mergers", "list"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.create_default_merger_registry") as mock_registry:
+                    with patch(
+                        "agent_manager.cli_extensions.merger_commands.MergerCommands.process_cli_command"
+                    ) as mock_process:
+                        with patch("agent_manager.agent_manager.get_output"):
+                            mock_config.return_value.ensure_directories = Mock()
 
-            main()
+                            main()
 
-            mock_registry.assert_called_once()
-            mock_process.assert_called_once()
-            args = mock_process.call_args[0][0]
-            assert args.mergers_command == "list"
+                            mock_registry.assert_called_once()
+                            mock_process.assert_called_once()
+                            args = mock_process.call_args[0][0]
+                            assert args.mergers_command == "list"
 
     def test_mergers_show_command(self):
         """Test mergers show command."""
-        with (
-            patch("sys.argv", ["agent-manager", "mergers", "show", "JsonMerger"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.create_default_merger_registry"),
-            patch("agent_manager.cli_extensions.merger_commands.MergerCommands.process_cli_command") as mock_process,
-            patch("agent_manager.output.get_output"),
-        ):
-            mock_config.return_value.ensure_directories = Mock()
+        with patch("sys.argv", ["agent-manager", "mergers", "show", "JsonMerger"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.create_default_merger_registry"):
+                    with patch(
+                        "agent_manager.cli_extensions.merger_commands.MergerCommands.process_cli_command"
+                    ) as mock_process:
+                        with patch("agent_manager.agent_manager.get_output"):
+                            mock_config.return_value.ensure_directories = Mock()
 
-            main()
+                            main()
 
-            args = mock_process.call_args[0][0]
-            assert args.mergers_command == "show"
-            assert args.name == "JsonMerger"
+                            args = mock_process.call_args[0][0]
+                            assert args.mergers_command == "show"
+                            assert args.merger == "JsonMerger"
 
     def test_mergers_command_early_return(self):
         """Test that mergers command returns early without repo operations."""
-        with (
-            patch("sys.argv", ["agent-manager", "mergers", "list"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.create_default_merger_registry"),
-            patch("agent_manager.cli_extensions.merger_commands.MergerCommands.process_cli_command"),
-            patch("agent_manager.output.get_output"),
-            patch("agent_manager.agent_manager.update_repositories") as mock_update,
-        ):
-            mock_config.return_value.ensure_directories = Mock()
+        with patch("sys.argv", ["agent-manager", "mergers", "list"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.create_default_merger_registry"):
+                    with patch("agent_manager.cli_extensions.merger_commands.MergerCommands.process_cli_command"):
+                        with patch("agent_manager.agent_manager.get_output"):
+                            with patch("agent_manager.agent_manager.update_repositories") as mock_update:
+                                mock_config.return_value.ensure_directories = Mock()
 
-            main()
+                                main()
 
-            # Should not call update_repositories
-            mock_update.assert_not_called()
+                                # Should not call update_repositories
+                                mock_update.assert_not_called()
 
 
 class TestUpdateCommand:
@@ -257,56 +240,50 @@ class TestUpdateCommand:
             ]
         }
 
-        with (
-            patch("sys.argv", ["agent-manager", "update"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.update_repositories") as mock_update,
-            patch("agent_manager.output.get_output"),
-        ):
-            mock_config_instance = Mock()
-            mock_config.return_value = mock_config_instance
-            mock_config_instance.initialize = Mock()
-            mock_config_instance.read.return_value = mock_config_data
+        with patch("sys.argv", ["agent-manager", "update"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.update_repositories") as mock_update:
+                    with patch("agent_manager.agent_manager.get_output"):
+                        mock_config_instance = Mock()
+                        mock_config.return_value = mock_config_instance
+                        mock_config_instance.initialize = Mock()
+                        mock_config_instance.read.return_value = mock_config_data
 
-            main()
+                        main()
 
-            mock_update.assert_called_once()
-            assert mock_update.call_args[0][0] == mock_config_data
-            assert mock_update.call_args[1]["force"] is False
+                        mock_update.assert_called_once()
+                        assert mock_update.call_args[0][0] == mock_config_data
+                        assert mock_update.call_args[1]["force"] is False
 
     def test_update_command_with_force_flag(self):
         """Test update command with --force flag."""
         mock_config_data = {"hierarchy": []}
 
-        with (
-            patch("sys.argv", ["agent-manager", "update", "--force"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.update_repositories") as mock_update,
-            patch("agent_manager.output.get_output"),
-        ):
-            mock_config_instance = Mock()
-            mock_config.return_value = mock_config_instance
-            mock_config_instance.read.return_value = mock_config_data
+        with patch("sys.argv", ["agent-manager", "update", "--force"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.update_repositories") as mock_update:
+                    with patch("agent_manager.agent_manager.get_output"):
+                        mock_config_instance = Mock()
+                        mock_config.return_value = mock_config_instance
+                        mock_config_instance.read.return_value = mock_config_data
 
-            main()
+                        main()
 
-            assert mock_update.call_args[1]["force"] is True
+                        assert mock_update.call_args[1]["force"] is True
 
     def test_update_command_returns_after_update(self):
         """Test that update command returns after updating repos."""
-        with (
-            patch("sys.argv", ["agent-manager", "update"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.update_repositories"),
-            patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent,
-            patch("agent_manager.output.get_output"),
-        ):
-            mock_config.return_value.read.return_value = {"hierarchy": []}
+        with patch("sys.argv", ["agent-manager", "update"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.update_repositories"):
+                    with patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent:
+                        with patch("agent_manager.agent_manager.get_output"):
+                            mock_config.return_value.read.return_value = {"hierarchy": []}
 
-            main()
+                            main()
 
-            # Should not call agent commands
-            mock_agent.assert_not_called()
+                            # Should not call agent commands
+                            mock_agent.assert_not_called()
 
 
 class TestNoCommand:
@@ -314,96 +291,87 @@ class TestNoCommand:
 
     def test_no_command_shows_help(self, capsys):
         """Test that running with no command shows help and exits cleanly."""
-        with (
-            patch("sys.argv", ["agent-manager"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.output.get_output"),
-        ):
-            mock_config.return_value.ensure_directories = Mock()
+        with patch("sys.argv", ["agent-manager"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.get_output"):
+                    mock_config.return_value.ensure_directories = Mock()
 
-            main()
+                    main()
 
-            # Should show help message
-            captured = capsys.readouterr()
-            assert "usage:" in captured.out or "agent-manager" in captured.out
+                    # Should show help message
+                    captured = capsys.readouterr()
+                    assert "usage:" in captured.out or "agent-manager" in captured.out
 
     def test_no_command_does_not_call_process_cli(self):
         """Test that running with no command doesn't call agent processing."""
-        with (
-            patch("sys.argv", ["agent-manager"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_process,
-            patch("agent_manager.output.get_output"),
-        ):
-            mock_config.return_value.ensure_directories = Mock()
+        with patch("sys.argv", ["agent-manager"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_process:
+                    with patch("agent_manager.agent_manager.get_output"):
+                        mock_config.return_value.ensure_directories = Mock()
 
-            main()
+                        main()
 
-            # Should NOT call process_cli_command
-            mock_process.assert_not_called()
+                        # Should NOT call process_cli_command
+                        mock_process.assert_not_called()
 
 
 class TestRunCommand:
     """Test run command execution."""
 
-    def test_run_command_routes_correctly(self):
-        """Test explicit 'run' command routes to AgentCommands."""
+    def test_run_command_explicit(self):
+        """Test explicit 'run' command."""
         mock_config_data = {"hierarchy": []}
 
-        with (
-            patch("sys.argv", ["agent-manager", "run"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.update_repositories"),
-            patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent,
-            patch("agent_manager.agent_manager.get_output"),
-        ):
-            mock_config.return_value.read.return_value = mock_config_data
+        with patch("sys.argv", ["agent-manager", "run"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.update_repositories"):
+                    with patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent:
+                        with patch("agent_manager.agent_manager.get_output"):
+                            mock_config.return_value.read.return_value = mock_config_data
 
-            main()
+                            main()
 
-            mock_agent.assert_called_once()
-            args, config_data = mock_agent.call_args[0]
-            assert args.command == "run"
-            assert config_data == mock_config_data
+                            mock_agent.assert_called_once()
+                            args, config_data = mock_agent.call_args[0]
+                            assert args.command == "run"
+                            assert config_data == mock_config_data
 
     def test_run_command_explicit(self):
         """Test that run command must be explicitly specified."""
         mock_config_data = {"hierarchy": []}
 
-        with (
-            patch("sys.argv", ["agent-manager", "run"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.update_repositories"),
-            patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent,
-            patch("agent_manager.agent_manager.get_output"),
-        ):
-            mock_config_instance = Mock()
-            mock_config.return_value = mock_config_instance
-            mock_config_instance.read.return_value = mock_config_data
-            # Mock initialize to avoid interactive prompts
-            mock_config_instance.initialize = Mock()
+        with patch("sys.argv", ["agent-manager", "run"]), patch("agent_manager.agent_manager.Config") as mock_config:
+            with patch("agent_manager.agent_manager.update_repositories"):
+                with patch("agent_manager.cli_extensions.agent_commands.get_agent_names", return_value=[]):
+                    with patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent:
+                        with patch("agent_manager.agent_manager.get_output"):
+                            mock_config_instance = Mock()
+                            mock_config.return_value = mock_config_instance
+                            mock_config_instance.read.return_value = mock_config_data
+                            # Mock initialize to avoid interactive prompts
+                            mock_config_instance.initialize = Mock()
 
-            main()
+                            main()
 
-            mock_agent.assert_called_once()
+                            mock_agent.assert_called_once()
 
     def test_run_command_with_agent_flag(self):
         """Test run command with specific agent selection."""
         mock_config_data = {"hierarchy": []}
 
-        with (
-            patch("sys.argv", ["agent-manager", "run", "--agent", "all"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.update_repositories"),
-            patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent,
-            patch("agent_manager.agent_manager.get_output"),
-        ):
-            mock_config.return_value.read.return_value = mock_config_data
+        with patch("sys.argv", ["agent-manager", "run", "--agent", "all"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.update_repositories"):
+                    with patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent:
+                        with patch("agent_manager.cli_extensions.agent_commands.get_agent_names", return_value=[]):
+                            with patch("agent_manager.agent_manager.get_output"):
+                                mock_config.return_value.read.return_value = mock_config_data
 
-            main()
+                                main()
 
-            args = mock_agent.call_args[0][0]
-            assert args.agent == "all"
+                                args = mock_agent.call_args[0][0]
+                                assert args.agent == "all"
 
     def test_run_updates_repos_before_running_agents(self):
         """Test that repositories are updated before running agents."""
@@ -416,18 +384,18 @@ class TestRunCommand:
         def track_agent(*args, **kwargs):
             call_order.append("agent")
 
-        with (
-            patch("sys.argv", ["agent-manager", "run"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.update_repositories", side_effect=track_update),
-            patch("agent_manager.agent_manager.AgentCommands.process_cli_command", side_effect=track_agent),
-            patch("agent_manager.output.get_output"),
-        ):
-            mock_config.return_value.read.return_value = mock_config_data
+        with patch("sys.argv", ["agent-manager", "run"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.update_repositories", side_effect=track_update):
+                    with patch(
+                        "agent_manager.agent_manager.AgentCommands.process_cli_command", side_effect=track_agent
+                    ):
+                        with patch("agent_manager.agent_manager.get_output"):
+                            mock_config.return_value.read.return_value = mock_config_data
 
-            main()
+                            main()
 
-            assert call_order == ["update", "agent"]
+                            assert call_order == ["update", "agent"]
 
 
 class TestConfigInitialization:
@@ -435,57 +403,51 @@ class TestConfigInitialization:
 
     def test_config_directories_ensured(self):
         """Test that config directories are ensured on startup."""
-        with (
-            patch("sys.argv", ["agent-manager", "config", "where"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.ConfigCommands.process_cli_command"),
-            patch("agent_manager.output.get_output"),
-        ):
-            mock_config_instance = Mock()
-            mock_config.return_value = mock_config_instance
+        with patch("sys.argv", ["agent-manager", "config", "where"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command"):
+                    with patch("agent_manager.agent_manager.get_output"):
+                        mock_config_instance = Mock()
+                        mock_config.return_value = mock_config_instance
 
-            main()
+                        main()
 
-            mock_config_instance.ensure_directories.assert_called_once()
+                        mock_config_instance.ensure_directories.assert_called_once()
 
     def test_config_initialize_skipped_if_exists(self):
         """Test that initialization is skipped if config already exists."""
         mock_config_data = {"hierarchy": []}
 
-        with (
-            patch("sys.argv", ["agent-manager", "run"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.update_repositories"),
-            patch("agent_manager.agent_manager.AgentCommands.process_cli_command"),
-            patch("agent_manager.output.get_output"),
-        ):
-            mock_config_instance = Mock()
-            mock_config.return_value = mock_config_instance
-            mock_config_instance.read.return_value = mock_config_data
+        with patch("sys.argv", ["agent-manager", "run"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.update_repositories"):
+                    with patch("agent_manager.agent_manager.AgentCommands.process_cli_command"):
+                        with patch("agent_manager.agent_manager.get_output"):
+                            mock_config_instance = Mock()
+                            mock_config.return_value = mock_config_instance
+                            mock_config_instance.read.return_value = mock_config_data
 
-            main()
+                            main()
 
-            # initialize should be called with skip_if_already_created=True
-            mock_config_instance.initialize.assert_called_once_with(skip_if_already_created=True)
+                            # initialize should be called with skip_if_already_created=True
+                            mock_config_instance.initialize.assert_called_once_with(skip_if_already_created=True)
 
     def test_config_read_called_for_run_command(self):
         """Test that config.read() is called for run/update commands."""
         mock_config_data = {"hierarchy": []}
 
-        with (
-            patch("sys.argv", ["agent-manager", "run"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.update_repositories"),
-            patch("agent_manager.agent_manager.AgentCommands.process_cli_command"),
-            patch("agent_manager.output.get_output"),
-        ):
-            mock_config_instance = Mock()
-            mock_config.return_value = mock_config_instance
-            mock_config_instance.read.return_value = mock_config_data
+        with patch("sys.argv", ["agent-manager", "run"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.update_repositories"):
+                    with patch("agent_manager.agent_manager.AgentCommands.process_cli_command"):
+                        with patch("agent_manager.agent_manager.get_output"):
+                            mock_config_instance = Mock()
+                            mock_config.return_value = mock_config_instance
+                            mock_config_instance.read.return_value = mock_config_data
 
-            main()
+                            main()
 
-            mock_config_instance.read.assert_called_once()
+                            mock_config_instance.read.assert_called_once()
 
 
 class TestErrorHandling:
@@ -493,34 +455,31 @@ class TestErrorHandling:
 
     def test_unknown_command_shows_help(self, capsys):
         """Test that unknown commands display help and exit."""
-        with (
-            patch("sys.argv", ["agent-manager", "unknown-command"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.update_repositories"),
-            patch("agent_manager.agent_manager.get_output"),
-        ):
-            mock_config.return_value.read.return_value = {"hierarchy": []}
+        with patch("sys.argv", ["agent-manager", "unknown-command"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.update_repositories"):
+                    with patch("agent_manager.cli_extensions.agent_commands.get_agent_names", return_value=[]):
+                        with patch("agent_manager.agent_manager.get_output"):
+                            mock_config.return_value.read.return_value = {"hierarchy": []}
 
-            with pytest.raises(SystemExit) as exc_info:
-                main()
+                            with pytest.raises(SystemExit) as exc_info:
+                                main()
 
-            assert exc_info.value.code == 2  # argparse returns 2 for invalid arguments
+                            assert exc_info.value.code == 2  # argparse returns 2 for invalid arguments
 
     def test_config_read_failure_propagates(self):
         """Test that config read failures propagate correctly."""
-        with (
-            patch("sys.argv", ["agent-manager", "run"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.output.get_output"),
-        ):
-            mock_config_instance = Mock()
-            mock_config.return_value = mock_config_instance
-            mock_config_instance.read.side_effect = SystemExit(1)
+        with patch("sys.argv", ["agent-manager", "run"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.get_output"):
+                    mock_config_instance = Mock()
+                    mock_config.return_value = mock_config_instance
+                    mock_config_instance.read.side_effect = SystemExit(1)
 
-            with pytest.raises(SystemExit) as exc_info:
-                main()
+                    with pytest.raises(SystemExit) as exc_info:
+                        main()
 
-            assert exc_info.value.code == 1
+                    assert exc_info.value.code == 1
 
 
 class TestIntegration:
@@ -545,84 +504,81 @@ class TestIntegration:
             ]
         }
 
-        with (
-            patch("sys.argv", ["agent-manager", "-vv", "run", "--agent", "all"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.update_repositories") as mock_update,
-            patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent,
-            patch("agent_manager.agent_manager.get_output") as mock_output,
-        ):
-            mock_output_instance = Mock(verbosity=0, use_color=True)
-            mock_output.return_value = mock_output_instance
+        with patch("sys.argv", ["agent-manager", "-vv", "run", "--agent", "all"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.update_repositories") as mock_update:
+                    with patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent:
+                        with patch("agent_manager.cli_extensions.agent_commands.get_agent_names", return_value=[]):
+                            with patch("agent_manager.agent_manager.get_output") as mock_output:
+                                mock_output_instance = Mock(verbosity=0, use_color=True)
+                                mock_output.return_value = mock_output_instance
 
-            mock_config_instance = Mock()
-            mock_config.return_value = mock_config_instance
-            mock_config_instance.read.return_value = mock_config_data
+                                mock_config_instance = Mock()
+                                mock_config.return_value = mock_config_instance
+                                mock_config_instance.read.return_value = mock_config_data
 
-            main()
+                                main()
 
-            # Verify full workflow
-            assert mock_output_instance.verbosity == 2
-            mock_config_instance.ensure_directories.assert_called_once()
-            mock_config_instance.initialize.assert_called_once_with(skip_if_already_created=True)
-            mock_config_instance.read.assert_called_once()
-            mock_update.assert_called_once_with(mock_config_data, force=False)
-            mock_agent.assert_called_once()
+                                # Verify full workflow
+                                assert mock_output_instance.verbosity == 2
+                                mock_config_instance.ensure_directories.assert_called_once()
+                                mock_config_instance.initialize.assert_called_once_with(skip_if_already_created=True)
+                                mock_config_instance.read.assert_called_once()
+                                mock_update.assert_called_once_with(mock_config_data, force=False)
+                                mock_agent.assert_called_once()
 
-            # Verify agent command args
-            args, config_data = mock_agent.call_args[0]
-            assert args.command == "run"
-            assert args.agent == "all"
-            assert config_data == mock_config_data
+                            # Verify agent command args
+                            args, config_data = mock_agent.call_args[0]
+                            assert args.command == "run"
+                            assert args.agent == "all"
+                            assert config_data == mock_config_data
 
     def test_config_command_workflow(self):
         """Test complete config management workflow."""
-        with (
-            patch("sys.argv", ["agent-manager", "-v", "config", "add", "team", "https://github.com/test/team"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.ConfigCommands.process_cli_command") as mock_process,
-            patch("agent_manager.agent_manager.get_output") as mock_output,
-        ):
-            mock_output_instance = Mock(verbosity=0, use_color=True)
-            mock_output.return_value = mock_output_instance
+        with patch("sys.argv", ["agent-manager", "-v", "config", "add", "team", "https://github.com/test/team"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command") as mock_process:
+                    with patch("agent_manager.agent_manager.get_output") as mock_output:
+                        mock_output_instance = Mock(verbosity=0, use_color=True)
+                        mock_output.return_value = mock_output_instance
 
-            mock_config_instance = Mock()
-            mock_config.return_value = mock_config_instance
+                        mock_config_instance = Mock()
+                        mock_config.return_value = mock_config_instance
 
-            main()
+                        main()
 
-            # Verify workflow
-            assert mock_output_instance.verbosity == 1
-            mock_config_instance.ensure_directories.assert_called_once()
-            mock_process.assert_called_once()
+                        # Verify workflow
+                        assert mock_output_instance.verbosity == 1
+                        mock_config_instance.ensure_directories.assert_called_once()
+                        mock_process.assert_called_once()
 
-            # Verify no repo operations
-            mock_config_instance.initialize.assert_not_called()
-            mock_config_instance.read.assert_not_called()
+                        # Verify no repo operations
+                        mock_config_instance.initialize.assert_not_called()
+                        mock_config_instance.read.assert_not_called()
 
     def test_mergers_configuration_workflow(self):
         """Test complete mergers configuration workflow."""
-        with (
-            patch("sys.argv", ["agent-manager", "mergers", "configure", "--merger", "JsonMerger"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.create_default_merger_registry") as mock_registry,
-            patch("agent_manager.cli_extensions.merger_commands.MergerCommands.process_cli_command") as mock_process,
-            patch("agent_manager.output.get_output"),
-        ):
-            mock_config_instance = Mock()
-            mock_config.return_value = mock_config_instance
+        with patch("sys.argv", ["agent-manager", "mergers", "configure", "--merger", "JsonMerger"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.create_default_merger_registry") as mock_registry:
+                    with patch(
+                        "agent_manager.cli_extensions.merger_commands.MergerCommands.process_cli_command"
+                    ) as mock_process:
+                        with patch("agent_manager.agent_manager.get_output"):
+                            mock_config_instance = Mock()
+                            mock_config.return_value = mock_config_instance
 
-            main()
+                            main()
 
-            # Verify workflow
-            mock_config_instance.ensure_directories.assert_called_once()
-            mock_registry.assert_called_once()
-            mock_process.assert_called_once()
+                            # Verify workflow
+                            mock_config_instance.ensure_directories.assert_called_once()
+                            mock_registry.assert_called_once()
+                            mock_process.assert_called_once()
 
-            # Verify args
-            args = mock_process.call_args[0][0]
-            assert args.mergers_command == "configure"
-            assert args.merger == "JsonMerger"
+                            # Verify args
+                            args = mock_process.call_args[0][0]
+                            assert args.mergers_command == "configure"
+                            assert args.merger == "JsonMerger"
 
 
 class TestFullIntegration:
@@ -675,6 +631,8 @@ class TestFullIntegration:
     def test_full_merge_integration(self, mock_config_data, temp_output_dir, test_data_path):
         """Test full integration: read config, merge files, write to TestAgent."""
         import json
+        import tempfile
+        from pathlib import Path
 
         import yaml
 
@@ -736,29 +694,28 @@ class TestFullIntegration:
 
     def test_run_command_flow(self, mock_config_data, temp_output_dir):
         """Test the run command flow through the CLI."""
+        from pathlib import Path
 
-        with (
-            patch("sys.argv", ["agent-manager", "run"]),
-            patch("agent_manager.agent_manager.Config") as mock_config,
-            patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent_cmd,
-            patch("agent_manager.agent_manager.update_repositories") as mock_update,
-        ):
-            # Setup mocks
-            mock_config_instance = Mock()
-            mock_config.return_value = mock_config_instance
-            mock_config_instance.ensure_directories = Mock()
-            mock_config_instance.initialize = Mock()
-            mock_config_instance.read.return_value = mock_config_data
+        with patch("sys.argv", ["agent-manager", "run"]):
+            with patch("agent_manager.agent_manager.Config") as mock_config:
+                with patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent_cmd:
+                    with patch("agent_manager.agent_manager.update_repositories") as mock_update:
+                        # Setup mocks
+                        mock_config_instance = Mock()
+                        mock_config.return_value = mock_config_instance
+                        mock_config_instance.ensure_directories = Mock()
+                        mock_config_instance.initialize = Mock()
+                        mock_config_instance.read.return_value = mock_config_data
 
-            # Run main
-            main()
+                        # Run main
+                        main()
 
-            # Verify the flow
-            mock_config_instance.ensure_directories.assert_called_once()
-            mock_config_instance.initialize.assert_called_once_with(skip_if_already_created=True)
-            mock_config_instance.read.assert_called_once()
-            mock_update.assert_called_once()
-            mock_agent_cmd.assert_called_once()
+                        # Verify the flow
+                        mock_config_instance.ensure_directories.assert_called_once()
+                        mock_config_instance.initialize.assert_called_once_with(skip_if_already_created=True)
+                        mock_config_instance.read.assert_called_once()
+                        mock_update.assert_called_once()
+                        mock_agent_cmd.assert_called_once()
 
     def test_agent_import(self):
         """Test that TestAgent can be imported and instantiated."""

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -317,24 +317,6 @@ class TestRunCommand:
     """Test run command execution."""
 
     def test_run_command_explicit(self):
-        """Test explicit 'run' command."""
-        mock_config_data = {"hierarchy": []}
-
-        with patch("sys.argv", ["agent-manager", "run"]):
-            with patch("agent_manager.agent_manager.Config") as mock_config:
-                with patch("agent_manager.agent_manager.update_repositories"):
-                    with patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent:
-                        with patch("agent_manager.agent_manager.get_output"):
-                            mock_config.return_value.read.return_value = mock_config_data
-
-                            main()
-
-                            mock_agent.assert_called_once()
-                            args, config_data = mock_agent.call_args[0]
-                            assert args.command == "run"
-                            assert config_data == mock_config_data
-
-    def test_run_command_explicit(self):
         """Test that run command must be explicitly specified."""
         mock_config_data = {"hierarchy": []}
 

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -206,7 +206,7 @@ class TestMergersCommand:
 
                             args = mock_process.call_args[0][0]
                             assert args.mergers_command == "show"
-                            assert args.merger == "JsonMerger"
+                            assert args.name == "JsonMerger"
 
     def test_mergers_command_early_return(self):
         """Test that mergers command returns early without repo operations."""


### PR DESCRIPTION
Includes option for getting root-level files (such as AGENTS.md) instead of just the relevant subdirectories.