### PR TITLE
V2 PR 1: Config schema + validation

### DIFF
--- a/agent_manager/cli_extensions/config_commands.py
+++ b/agent_manager/cli_extensions/config_commands.py
@@ -1,12 +1,9 @@
-"""CLI commands for managing configuration."""
+"""CLI commands for managing configuration (V2 schema)."""
 
 import argparse
 import sys
 
-import yaml
-
 from agent_manager.config import Config
-from agent_manager.core import create_repo
 from agent_manager.output import MessageType, VerbosityLevel, message
 
 
@@ -20,93 +17,65 @@ class ConfigCommands:
         Args:
             subparsers: The subparsers object to add commands to
         """
-        # Config command group
         config_parser = subparsers.add_parser("config", help="Manage configuration")
         config_subparsers = config_parser.add_subparsers(dest="config_command", help="Configuration commands")
 
-        # config init
-        config_subparsers.add_parser(
-            "init",
-            help="Initialize or reinitialize configuration",
-            description="Create a new configuration file at ~/.agent-manager/config.yaml through an interactive setup wizard. If a configuration already exists, it will be re-initialized.",
-        )
-
         # config show
-        show_parser = config_subparsers.add_parser(
+        config_subparsers.add_parser(
             "show",
-            help="Display current hierarchy",
-            description="Display the current configuration hierarchy, showing each level's name, repository type, and URL in priority order (lowest to highest).",
+            help="Display current configuration",
+            description="Display the current configuration including repos, defaults, and directories.",
         )
-        show_parser.add_argument("--resolve-paths", action="store_true", help="Resolve file:// URLs to absolute paths")
-
-        # config add
-        add_parser = config_subparsers.add_parser(
-            "add",
-            help="Add a new hierarchy level",
-            description="Add a new hierarchy level with a name and repository URL. The level is appended to the end (highest priority) unless --position is specified.",
-        )
-        add_parser.add_argument("name", help="Name of the hierarchy level")
-        add_parser.add_argument("url", help="Repository URL (git URL or file:// path)")
-        add_parser.add_argument("--position", type=int, help="Position to insert (0-based, default: append to end)")
-
-        # config remove
-        remove_parser = config_subparsers.add_parser(
-            "remove",
-            help="Remove a hierarchy level",
-            description="Remove a hierarchy level by name from the configuration. This does not delete any cached repository data on disk.",
-        )
-        remove_parser.add_argument("name", help="Name of the hierarchy level to remove")
-
-        # config update
-        update_parser = config_subparsers.add_parser(
-            "update",
-            help="Update an existing hierarchy level",
-            description="Change the URL or name of an existing hierarchy level. At least one of --url or --rename must be provided.",
-        )
-        update_parser.add_argument("name", help="Name of the hierarchy level to update")
-        update_parser.add_argument("--url", help="New repository URL (git URL or file:// path)")
-        update_parser.add_argument("--rename", help="New name for the hierarchy level")
-
-        # config move
-        move_parser = config_subparsers.add_parser(
-            "move",
-            help="Move a hierarchy level to a new position",
-            description="Change the position of a hierarchy level within the priority order. Levels later in the list have higher priority and their values take precedence during merging.",
-        )
-        move_parser.add_argument("name", help="Name of the hierarchy level to move")
-        move_group = move_parser.add_mutually_exclusive_group(required=True)
-        move_group.add_argument("--position", type=int, help="New position (0-based)")
-        move_group.add_argument("--up", action="store_true", help="Move up one position")
-        move_group.add_argument("--down", action="store_true", help="Move down one position")
 
         # config validate
         config_subparsers.add_parser(
             "validate",
-            help="Validate all repository URLs",
-            description="Check that all repository URLs in the hierarchy are valid and accessible. Reports which repositories pass or fail validation.",
+            help="Validate configuration",
+            description="Validate the configuration file structure and check that all repository URLs are accessible.",
         )
 
-        # config export
-        export_parser = config_subparsers.add_parser(
-            "export",
-            help="Export configuration to a file or stdout",
-            description="Export the current configuration as YAML to a file or to stdout. Useful for backing up or sharing configurations.",
+        # config template
+        config_subparsers.add_parser(
+            "template",
+            help="Dump a starter configuration template to stdout",
+            description="Print a commented YAML template to stdout that can be redirected to a config file.",
         )
-        export_parser.add_argument("file", nargs="?", help="Output file (default: stdout)")
 
-        # config import
-        import_parser = config_subparsers.add_parser(
-            "import",
-            help="Import configuration from a file",
-            description="Import a configuration from a YAML file, replacing the current configuration. You will be prompted before overwriting an existing configuration.",
+        # config defaults
+        defaults_parser = config_subparsers.add_parser(
+            "defaults",
+            help="Show or set default hierarchy and agents",
+            description="Show or set the default_hierarchy and default_agents. "
+            "When called with flags, the lists are replaced entirely (declarative).",
         )
-        import_parser.add_argument("file", help="Input file to import")
+        defaults_parser.add_argument(
+            "--repos", nargs="+", metavar="NAME",
+            help="Set default_hierarchy (declarative, full replace)",
+        )
+        defaults_parser.add_argument(
+            "--agents", nargs="+", metavar="NAME",
+            help="Set default_agents (declarative, full replace)",
+        )
 
         # config where
         config_subparsers.add_parser(
             "where",
             help="Show configuration file location",
-            description="Show the file paths for the configuration file, config directory, and repos directory, along with whether each exists on disk.",
+            description="Show the file paths for the configuration file, config directory, and repos directory.",
+        )
+
+        # config init (placeholder for future wizard, currently creates from template)
+        config_subparsers.add_parser(
+            "init",
+            help="Initialize configuration (interactive wizard)",
+            description="Create a new configuration file through an interactive setup wizard.",
+        )
+
+        # config edit (placeholder for future editor integration)
+        config_subparsers.add_parser(
+            "edit",
+            help="Edit configuration in $EDITOR",
+            description="Open the configuration file in your default editor, validate on save.",
         )
 
     @staticmethod
@@ -118,214 +87,179 @@ class ConfigCommands:
             config: Config instance to operate on
         """
         if args.config_command is None:
-            # No subcommand provided, show available commands
             message("Usage: agent-manager config <command>", MessageType.NORMAL, VerbosityLevel.ALWAYS)
             message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
             message("Available commands:", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("  init      Initialize or reinitialize configuration", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("  show      Display current hierarchy", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("  add       Add a new hierarchy level", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("  remove    Remove a hierarchy level", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("  update    Update an existing hierarchy level", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("  move      Move a hierarchy level to a new position", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("  validate  Validate all repository URLs", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("  export    Export configuration to a file or stdout", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("  import    Import configuration from a file", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("  where     Show configuration file location", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("  show       Display current configuration", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("  validate   Validate configuration", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("  template   Dump starter template to stdout", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("  defaults   Show or set default hierarchy/agents", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("  where      Show configuration file location", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("  init       Initialize configuration (wizard)", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("  edit       Edit configuration in $EDITOR", MessageType.NORMAL, VerbosityLevel.ALWAYS)
             return
-        elif args.config_command == "init":
-            config.initialize(skip_if_already_created=False)
         elif args.config_command == "show":
-            resolve = getattr(args, "resolve_paths", False)
-            ConfigCommands.display(config, resolve_paths=resolve)
-        elif args.config_command == "add":
-            config.add_level(args.name, args.url, args.position)
-        elif args.config_command == "remove":
-            config.remove_level(args.name)
-        elif args.config_command == "update":
-            config.update_level(args.name, args.url, args.rename)
-        elif args.config_command == "move":
-            direction = None
-            if getattr(args, "up", False):
-                direction = "up"
-            elif getattr(args, "down", False):
-                direction = "down"
-            config.move_level(args.name, args.position, direction)
+            ConfigCommands.display(config)
         elif args.config_command == "validate":
             ConfigCommands.validate_all(config)
-        elif args.config_command == "export":
-            output_file = getattr(args, "file", None)
-            ConfigCommands.export_config(config, output_file)
-        elif args.config_command == "import":
-            ConfigCommands.import_config(config, args.file)
+        elif args.config_command == "template":
+            ConfigCommands.template()
+        elif args.config_command == "defaults":
+            repos = getattr(args, "repos", None)
+            agents = getattr(args, "agents", None)
+            ConfigCommands.defaults(config, repos, agents)
         elif args.config_command == "where":
             ConfigCommands.show_location(config)
+        elif args.config_command == "init":
+            message("Interactive wizard not yet implemented. Use 'config template' to generate a starter config.",
+                    MessageType.WARNING, VerbosityLevel.ALWAYS)
+        elif args.config_command == "edit":
+            message("Editor integration not yet implemented. Use 'config where' to find the file path.",
+                    MessageType.WARNING, VerbosityLevel.ALWAYS)
         else:
-            # This shouldn't happen if argparse is set up correctly
             message("Unknown config command", MessageType.ERROR, VerbosityLevel.ALWAYS)
             sys.exit(1)
 
     @staticmethod
-    def display(config: Config, resolve_paths: bool = False) -> None:
-        """Display the current hierarchy configuration.
+    def display(config: Config) -> None:
+        """Display the current configuration.
 
         Args:
             config: Config instance
-            resolve_paths: If True, show resolved paths for repositories
         """
         if not config.exists():
-            message(
-                "No configuration file found. Run without arguments to create one.",
-                MessageType.ERROR,
-                VerbosityLevel.ALWAYS,
-            )
+            message("No configuration file found. Run 'agent-manager config init' to create one.",
+                    MessageType.ERROR, VerbosityLevel.ALWAYS)
             sys.exit(1)
 
         config_data = config.read()
-        message("\nCurrent Hierarchy (lowest to highest priority):\n", MessageType.NORMAL, VerbosityLevel.ALWAYS)
 
-        for idx, entry in enumerate(config_data["hierarchy"], 1):
-            priority = "→" * idx
-            message(f"  {priority} {entry['name']}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        # Repos
+        repos = config_data.get("repos", [])
+        message("\n=== Repos ===\n", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        if repos:
+            for entry in repos:
+                message(f"  {entry['name']} ({entry.get('repo_type', 'unknown')})",
+                        MessageType.NORMAL, VerbosityLevel.ALWAYS)
+                message(f"    URL: {entry['url']}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        else:
+            message("  (none)", MessageType.NORMAL, VerbosityLevel.ALWAYS)
 
-            message(f"      Type: {entry.get('repo_type', 'unknown')}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        # Default hierarchy
+        default_hierarchy = config_data.get("default_hierarchy", [])
+        message("\n=== Default Hierarchy ===\n", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        if default_hierarchy:
+            for idx, name in enumerate(default_hierarchy, 1):
+                message(f"  {idx}. {name}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        else:
+            message("  (not set)", MessageType.NORMAL, VerbosityLevel.ALWAYS)
 
-            url = entry["url"]
-            message(f"      URL: {url}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        # Default agents
+        default_agents = config_data.get("default_agents", [])
+        message("\n=== Default Agents ===\n", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        if default_agents:
+            for name in default_agents:
+                message(f"  - {name}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        else:
+            message("  (not set -- falls back to all enabled agents)", MessageType.NORMAL, VerbosityLevel.ALWAYS)
 
-            # Use pluggable repo architecture for resolved display
-            if resolve_paths:
-                try:
-                    # Create temporary repo instance for display
-                    repo = create_repo(entry["name"], entry["url"], config.repos_directory, entry["repo_type"])
-                    resolved = repo.get_display_url()
-                    # Only show if different from original URL
-                    if resolved != url:
-                        message(f"      Resolved: {resolved}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-                except Exception as e:
-                    message(f"Failed to resolve path for {entry['name']}: {e}", MessageType.DEBUG, VerbosityLevel.DEBUG)
+        # Directories
+        directories = config_data.get("directories", {})
+        message("\n=== Directories ===\n", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        if directories:
+            for dir_path, dir_config in directories.items():
+                if dir_config is None:
+                    dir_config = {}
+                dir_type = dir_config.get("type", "unset")
+                agents = dir_config.get("agents")
+                hierarchy = dir_config.get("hierarchy")
 
-            message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+                message(f"  {dir_path}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+                message(f"    type: {dir_type}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+                if agents:
+                    message(f"    agents: {', '.join(agents)}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+                else:
+                    message("    agents: (inherits default)", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+                if hierarchy:
+                    message(f"    hierarchy: {' -> '.join(hierarchy)}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+                else:
+                    message("    hierarchy: (inherits default)", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        else:
+            message("  (none)", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+
+        message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
 
     @staticmethod
     def validate_all(config: Config) -> None:
-        """Validate all repository URLs in the configuration.
+        """Validate configuration structure and repository URLs.
 
         Args:
             config: Config instance
         """
         if not config.exists():
-            message(
-                "No configuration file found. Run without arguments to create one.",
-                MessageType.ERROR,
-                VerbosityLevel.ALWAYS,
-            )
+            message("No configuration file found. Run 'agent-manager config init' to create one.",
+                    MessageType.ERROR, VerbosityLevel.ALWAYS)
             sys.exit(1)
 
+        # First validate structure (read does this)
         config_data = config.read()
-        message("\nValidating all repositories...\n", MessageType.INFO, VerbosityLevel.EXTRA_VERBOSE)
+
+        repos = config_data.get("repos", [])
+        message("\nValidating repository URLs...\n", MessageType.NORMAL, VerbosityLevel.ALWAYS)
 
         all_valid = True
-        for idx, entry in enumerate(config_data["hierarchy"]):
+        for idx, entry in enumerate(repos):
             name = entry["name"]
             url = entry["url"]
+            total = len(repos)
 
-            total = len(config_data["hierarchy"])
             message(f"[{idx + 1}/{total}] {name}: {url}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-
             if config.validate_repo_url(url):
-                message("  ✓ Valid", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
+                message("  Valid", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
             else:
-                message("  ✗ Invalid or inaccessible", MessageType.ERROR, VerbosityLevel.ALWAYS)
+                message("  Invalid or inaccessible", MessageType.ERROR, VerbosityLevel.ALWAYS)
                 all_valid = False
 
         message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
         if all_valid:
-            message("✓ All repositories are valid and accessible!", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
+            message("All repositories are valid and accessible!", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
         else:
-            message(
-                "Some repositories failed validation. Please check the errors above.",
-                MessageType.WARNING,
-                VerbosityLevel.ALWAYS,
-            )
+            message("Some repositories failed validation.", MessageType.WARNING, VerbosityLevel.ALWAYS)
             sys.exit(1)
 
     @staticmethod
-    def export_config(config: Config, output_file: str | None = None) -> None:
-        """Export configuration to a file or stdout.
-
-        Args:
-            config: Config instance
-            output_file: Optional output file path. If None, write to stdout.
-        """
-        if not config.exists():
-            message("No configuration file found. Nothing to export.", MessageType.ERROR, VerbosityLevel.ALWAYS)
-            sys.exit(1)
-
-        config_data = config.read()
-
-        # Remove repo objects before exporting (they're not serializable)
-        export_data = {"hierarchy": []}
-        for entry in config_data["hierarchy"]:
-            export_entry = {"name": entry["name"], "url": entry["url"], "repo_type": entry["repo_type"]}
-            export_data["hierarchy"].append(export_entry)
-
-        # Include mergers section if present
-        if "mergers" in config_data:
-            export_data["mergers"] = config_data["mergers"]
-
-        if output_file:
-            try:
-                with open(output_file, "w") as f:
-                    yaml.dump(export_data, f, default_flow_style=False, sort_keys=False)
-                message(f"Configuration exported to {output_file}", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
-            except Exception as e:
-                message(f"Failed to export configuration: {e}", MessageType.ERROR, VerbosityLevel.ALWAYS)
-                sys.exit(1)
-        else:
-            # Write to stdout
-            print(yaml.dump(export_data, default_flow_style=False, sort_keys=False))
+    def template() -> None:
+        """Dump a starter configuration template to stdout."""
+        print(Config.generate_template())
 
     @staticmethod
-    def import_config(config: Config, input_file: str) -> None:
-        """Import configuration from a file.
+    def defaults(config: Config, repos: list[str] | None = None, agents: list[str] | None = None) -> None:
+        """Show or set default_hierarchy and default_agents.
 
         Args:
             config: Config instance
-            input_file: Input file path to import from
+            repos: If provided, set default_hierarchy (full replace)
+            agents: If provided, set default_agents (full replace)
         """
-        try:
-            with open(input_file) as f:
-                imported_data = yaml.safe_load(f)
-        except FileNotFoundError:
-            message(f"File not found: {input_file}", MessageType.ERROR, VerbosityLevel.ALWAYS)
-            sys.exit(1)
-        except yaml.YAMLError as e:
-            message(f"Invalid YAML file: {e}", MessageType.ERROR, VerbosityLevel.ALWAYS)
-            sys.exit(1)
-        except Exception as e:
-            message(f"Failed to read file: {e}", MessageType.ERROR, VerbosityLevel.ALWAYS)
-            sys.exit(1)
+        if repos is None and agents is None:
+            # Show current defaults
+            defaults = config.get_defaults()
+            message("\nDefault hierarchy:", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            if defaults["default_hierarchy"]:
+                for idx, name in enumerate(defaults["default_hierarchy"], 1):
+                    message(f"  {idx}. {name}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            else:
+                message("  (not set)", MessageType.NORMAL, VerbosityLevel.ALWAYS)
 
-        # Validate imported data
-        if not isinstance(imported_data, dict) or "hierarchy" not in imported_data:
-            message("Invalid configuration file: missing 'hierarchy' key", MessageType.ERROR, VerbosityLevel.ALWAYS)
-            sys.exit(1)
-
-        # Warn if overwriting existing config
-        if config.exists():
-            response = input(f"Configuration file already exists at {config.config_file}. Overwrite? (yes/no): ")
-            if response.lower() not in ["yes", "y"]:
-                message("Import cancelled.", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-                return
-
-        # Write imported config
-        try:
-            config.write(imported_data)
-            message(f"✓ Configuration imported from {input_file}", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
-        except Exception as e:
-            message(f"Failed to import configuration: {e}", MessageType.ERROR, VerbosityLevel.ALWAYS)
-            sys.exit(1)
+            message("\nDefault agents:", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            if defaults["default_agents"]:
+                for name in defaults["default_agents"]:
+                    message(f"  - {name}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            else:
+                message("  (not set -- falls back to all enabled agents)", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        else:
+            config.set_defaults(repos=repos, agents=agents)
 
     @staticmethod
     def show_location(config: Config) -> None:
@@ -340,21 +274,20 @@ class ConfigCommands:
         message(f"  Config file:      {config.config_file}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
         message(f"  Repos directory:  {config.repos_directory}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
 
-        # Show status
         message("\nStatus:", MessageType.NORMAL, VerbosityLevel.ALWAYS)
         if config.config_file.exists():
-            message("  ✓ Configuration file exists", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
+            message("  Config file exists", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
         else:
-            message("  ✗ Configuration file does not exist", MessageType.WARNING, VerbosityLevel.ALWAYS)
+            message("  Config file does not exist", MessageType.WARNING, VerbosityLevel.ALWAYS)
 
         if config.config_directory.exists():
-            message("  ✓ Config directory exists", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
+            message("  Config directory exists", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
         else:
-            message("  ✗ Config directory does not exist", MessageType.WARNING, VerbosityLevel.ALWAYS)
+            message("  Config directory does not exist", MessageType.WARNING, VerbosityLevel.ALWAYS)
 
         if config.repos_directory.exists():
-            message("  ✓ Repos directory exists", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
+            message("  Repos directory exists", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
         else:
-            message("  ✗ Repos directory does not exist", MessageType.WARNING, VerbosityLevel.ALWAYS)
+            message("  Repos directory does not exist", MessageType.WARNING, VerbosityLevel.ALWAYS)
 
         message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)

--- a/agent_manager/config/__init__.py
+++ b/agent_manager/config/__init__.py
@@ -1,5 +1,5 @@
 """Configuration management for agent-manager."""
 
-from .config import Config, HierarchyEntry
+from .config import Config, ConfigData, ConfigError, DirectoryEntry, RepoEntry
 
-__all__ = ["Config", "HierarchyEntry"]
+__all__ = ["Config", "ConfigData", "ConfigError", "DirectoryEntry", "RepoEntry"]

--- a/tests/cli_extensions/test_config_commands.py
+++ b/tests/cli_extensions/test_config_commands.py
@@ -1,5 +1,6 @@
-"""Tests for cli_extensions/config_commands.py - Config CLI commands."""
+"""Tests for cli_extensions/config_commands.py - V2 Config CLI commands."""
 
+import argparse
 from unittest.mock import Mock, patch
 
 import pytest
@@ -10,302 +11,146 @@ from agent_manager.config.config import Config
 
 
 class TestConfigCommandsAddCliArguments:
-    """Test cases for add_cli_arguments method."""
+    """Test that all V2 subcommands are registered."""
 
     def test_adds_config_parser(self):
-        """Test that config parser is added."""
         mock_subparsers = Mock()
         mock_parser = Mock()
         mock_subparsers.add_parser.return_value = mock_parser
-
         ConfigCommands.add_cli_arguments(mock_subparsers)
-
-        # Should add config parser
         assert mock_subparsers.add_parser.called
 
-    def test_adds_all_subcommands(self):
-        """Test that all config subcommands are added."""
-        import argparse
-
+    def test_adds_expected_subcommands(self):
         parser = argparse.ArgumentParser()
         subparsers = parser.add_subparsers(dest="command")
-
         ConfigCommands.add_cli_arguments(subparsers)
 
-        # Parse each subcommand to verify they exist
-        commands = ["init", "show", "add", "remove", "update", "move", "validate", "export", "import", "where"]
-
-        for cmd in commands:
-            if cmd in ["add", "remove", "update", "move", "import"]:
-                # These require additional arguments
-                continue
+        # Commands that don't require positional args
+        for cmd in ["show", "validate", "template", "where", "init", "edit"]:
             args = parser.parse_args(["config", cmd])
-            assert args.command == "config"
             assert args.config_command == cmd
 
 
 class TestConfigCommandsProcessCliCommand:
-    """Test cases for process_cli_command method."""
-
-    def test_processes_init_command(self):
-        """Test processing of init command."""
-        args = Mock()
-        args.config_command = "init"
-
-        config = Mock(spec=Config)
-
-        ConfigCommands.process_cli_command(args, config)
-
-        config.initialize.assert_called_once_with(skip_if_already_created=False)
 
     @patch("agent_manager.cli_extensions.config_commands.ConfigCommands.display")
-    def test_processes_show_command(self, mock_display):
-        """Test processing of show command."""
-        args = Mock()
-        args.config_command = "show"
-        args.resolve_paths = False
-
+    def test_show(self, mock_display):
+        args = Mock(config_command="show")
         config = Mock(spec=Config)
-
         ConfigCommands.process_cli_command(args, config)
-
-        mock_display.assert_called_once_with(config, resolve_paths=False)
-
-    @patch("agent_manager.cli_extensions.config_commands.ConfigCommands.display")
-    def test_processes_show_command_with_resolve(self, mock_display):
-        """Test processing of show command with resolve_paths."""
-        args = Mock()
-        args.config_command = "show"
-        args.resolve_paths = True
-
-        config = Mock(spec=Config)
-
-        ConfigCommands.process_cli_command(args, config)
-
-        mock_display.assert_called_once_with(config, resolve_paths=True)
-
-    def test_processes_add_command(self):
-        """Test processing of add command."""
-        args = Mock()
-        args.config_command = "add"
-        args.name = "team"
-        args.url = "https://github.com/team/repo"
-        args.position = None
-
-        config = Mock(spec=Config)
-
-        ConfigCommands.process_cli_command(args, config)
-
-        config.add_level.assert_called_once_with("team", "https://github.com/team/repo", None)
-
-    def test_processes_remove_command(self):
-        """Test processing of remove command."""
-        args = Mock()
-        args.config_command = "remove"
-        args.name = "team"
-
-        config = Mock(spec=Config)
-
-        ConfigCommands.process_cli_command(args, config)
-
-        config.remove_level.assert_called_once_with("team")
-
-    def test_processes_update_command(self):
-        """Test processing of update command."""
-        args = Mock()
-        args.config_command = "update"
-        args.name = "team"
-        args.url = "https://github.com/team/new-repo"
-        args.rename = "new-team"
-
-        config = Mock(spec=Config)
-
-        ConfigCommands.process_cli_command(args, config)
-
-        config.update_level.assert_called_once_with("team", "https://github.com/team/new-repo", "new-team")
-
-    def test_processes_move_command_with_position(self):
-        """Test processing of move command with position."""
-        args = Mock()
-        args.config_command = "move"
-        args.name = "team"
-        args.position = 2
-        args.up = False
-        args.down = False
-
-        config = Mock(spec=Config)
-
-        ConfigCommands.process_cli_command(args, config)
-
-        config.move_level.assert_called_once_with("team", 2, None)
-
-    def test_processes_move_command_with_up(self):
-        """Test processing of move command with up direction."""
-        args = Mock()
-        args.config_command = "move"
-        args.name = "team"
-        args.position = None
-        args.up = True
-        args.down = False
-
-        config = Mock(spec=Config)
-
-        ConfigCommands.process_cli_command(args, config)
-
-        config.move_level.assert_called_once_with("team", None, "up")
-
-    def test_processes_move_command_with_down(self):
-        """Test processing of move command with down direction."""
-        args = Mock()
-        args.config_command = "move"
-        args.name = "team"
-        args.position = None
-        args.up = False
-        args.down = True
-
-        config = Mock(spec=Config)
-
-        ConfigCommands.process_cli_command(args, config)
-
-        config.move_level.assert_called_once_with("team", None, "down")
+        mock_display.assert_called_once_with(config)
 
     @patch("agent_manager.cli_extensions.config_commands.ConfigCommands.validate_all")
-    def test_processes_validate_command(self, mock_validate):
-        """Test processing of validate command."""
-        args = Mock()
-        args.config_command = "validate"
-
+    def test_validate(self, mock_validate):
+        args = Mock(config_command="validate")
         config = Mock(spec=Config)
-
         ConfigCommands.process_cli_command(args, config)
-
         mock_validate.assert_called_once_with(config)
 
-    @patch("agent_manager.cli_extensions.config_commands.ConfigCommands.export_config")
-    def test_processes_export_command(self, mock_export):
-        """Test processing of export command."""
-        args = Mock()
-        args.config_command = "export"
-        args.file = "output.yaml"
-
+    @patch("agent_manager.cli_extensions.config_commands.ConfigCommands.template")
+    def test_template(self, mock_template):
+        args = Mock(config_command="template")
         config = Mock(spec=Config)
-
         ConfigCommands.process_cli_command(args, config)
+        mock_template.assert_called_once()
 
-        mock_export.assert_called_once_with(config, "output.yaml")
-
-    @patch("agent_manager.cli_extensions.config_commands.ConfigCommands.import_config")
-    def test_processes_import_command(self, mock_import):
-        """Test processing of import command."""
-        args = Mock()
-        args.config_command = "import"
-        args.file = "input.yaml"
-
+    @patch("agent_manager.cli_extensions.config_commands.ConfigCommands.defaults")
+    def test_defaults_show(self, mock_defaults):
+        args = Mock(config_command="defaults", repos=None, agents=None)
         config = Mock(spec=Config)
-
         ConfigCommands.process_cli_command(args, config)
+        mock_defaults.assert_called_once_with(config, None, None)
 
-        mock_import.assert_called_once_with(config, "input.yaml")
+    @patch("agent_manager.cli_extensions.config_commands.ConfigCommands.defaults")
+    def test_defaults_set(self, mock_defaults):
+        args = Mock(config_command="defaults", repos=["a", "b"], agents=["cursor"])
+        config = Mock(spec=Config)
+        ConfigCommands.process_cli_command(args, config)
+        mock_defaults.assert_called_once_with(config, ["a", "b"], ["cursor"])
 
     @patch("agent_manager.cli_extensions.config_commands.ConfigCommands.show_location")
-    def test_processes_where_command(self, mock_show):
-        """Test processing of where command."""
-        args = Mock()
-        args.config_command = "where"
-
+    def test_where(self, mock_show):
+        args = Mock(config_command="where")
         config = Mock(spec=Config)
-
         ConfigCommands.process_cli_command(args, config)
-
         mock_show.assert_called_once_with(config)
 
-    def test_processes_unknown_command(self):
-        """Test processing of unknown command."""
-        args = Mock()
-        args.config_command = "unknown"
-
+    def test_unknown_command(self):
+        args = Mock(config_command="unknown")
         config = Mock(spec=Config)
-
         with patch("agent_manager.cli_extensions.config_commands.message"), pytest.raises(SystemExit):
             ConfigCommands.process_cli_command(args, config)
 
-    def test_shows_help_when_no_subcommand(self):
-        """Test that no subcommand shows available commands instead of error."""
-        args = Mock()
-        args.config_command = None
-
+    def test_no_subcommand_shows_help(self):
+        args = Mock(config_command=None)
         config = Mock(spec=Config)
         messages = []
 
-        def capture_message(msg, *args, **kwargs):
+        def capture(msg, *a, **kw):
             messages.append(msg)
 
-        with patch("agent_manager.cli_extensions.config_commands.message", side_effect=capture_message):
-            # Should return without error, not raise SystemExit
+        with patch("agent_manager.cli_extensions.config_commands.message", side_effect=capture):
             ConfigCommands.process_cli_command(args, config)
 
-        # Should have printed available subcommands
-        assert any("Available" in str(m) or "subcommand" in str(m).lower() for m in messages)
+        assert any("Available" in str(m) for m in messages)
 
 
 class TestConfigCommandsDisplay:
-    """Test cases for display method."""
 
-    def test_display_shows_hierarchy(self, tmp_path):
-        """Test that display shows hierarchy configuration."""
+    def test_display_shows_repos_and_directories(self):
         config = Mock(spec=Config)
         config.exists.return_value = True
         config.read.return_value = {
-            "hierarchy": [
+            "repos": [
                 {"name": "org", "url": "https://github.com/org/repo", "repo_type": "git"},
-                {"name": "team", "url": "file:///tmp/team", "repo_type": "file"},
-            ]
+            ],
+            "default_hierarchy": ["org"],
+            "default_agents": ["cursor"],
+            "directories": {
+                "HOME": {"type": "local", "agents": ["cursor"], "hierarchy": ["org"]},
+            },
         }
 
         with patch("agent_manager.cli_extensions.config_commands.message"):
             ConfigCommands.display(config)
 
-        config.exists.assert_called_once()
-        config.read.assert_called_once()
-
     def test_display_errors_when_no_config(self):
-        """Test that display errors when config doesn't exist."""
         config = Mock(spec=Config)
         config.exists.return_value = False
 
         with patch("agent_manager.cli_extensions.config_commands.message"), pytest.raises(SystemExit):
             ConfigCommands.display(config)
 
-    @patch("agent_manager.cli_extensions.config_commands.create_repo")
-    def test_display_resolves_paths(self, mock_create, tmp_path):
-        """Test that display resolves file paths when requested."""
-        mock_repo = Mock()
-        mock_repo.get_display_url.return_value = "/resolved/path"
-        mock_create.return_value = mock_repo
-
-        config = Mock(spec=Config)
-        config.exists.return_value = True
-        config.repos_directory = tmp_path
-        config.read.return_value = {"hierarchy": [{"name": "team", "url": "file:///tmp/team", "repo_type": "file"}]}
-
-        with patch("agent_manager.cli_extensions.config_commands.message"):
-            ConfigCommands.display(config, resolve_paths=True)
-
-        mock_create.assert_called_once()
-
-
-class TestConfigCommandsValidateAll:
-    """Test cases for validate_all method."""
-
-    def test_validates_all_repositories(self, tmp_path):
-        """Test validation of all repositories."""
+    def test_display_handles_none_directory(self):
         config = Mock(spec=Config)
         config.exists.return_value = True
         config.read.return_value = {
-            "hierarchy": [
+            "repos": [],
+            "directories": {"HOME": None},
+        }
+
+        with patch("agent_manager.cli_extensions.config_commands.message"):
+            ConfigCommands.display(config)
+
+    def test_display_handles_no_directories(self):
+        config = Mock(spec=Config)
+        config.exists.return_value = True
+        config.read.return_value = {"repos": []}
+
+        with patch("agent_manager.cli_extensions.config_commands.message"):
+            ConfigCommands.display(config)
+
+
+class TestConfigCommandsValidateAll:
+
+    def test_validates_all_repos(self):
+        config = Mock(spec=Config)
+        config.exists.return_value = True
+        config.read.return_value = {
+            "repos": [
                 {"name": "org", "url": "https://github.com/org/repo", "repo_type": "git"},
                 {"name": "team", "url": "file:///tmp/team", "repo_type": "file"},
-            ]
+            ],
         }
         config.validate_repo_url.return_value = True
 
@@ -314,23 +159,18 @@ class TestConfigCommandsValidateAll:
 
         assert config.validate_repo_url.call_count == 2
 
-    def test_validates_all_reports_failures(self):
-        """Test that validate_all reports validation failures."""
+    def test_exits_on_failure(self):
         config = Mock(spec=Config)
         config.exists.return_value = True
         config.read.return_value = {
-            "hierarchy": [
-                {"name": "org", "url": "https://github.com/org/repo", "repo_type": "git"},
-                {"name": "bad", "url": "invalid://url", "repo_type": "unknown"},
-            ]
+            "repos": [{"name": "bad", "url": "bad", "repo_type": "x"}],
         }
-        config.validate_repo_url.side_effect = [True, False]
+        config.validate_repo_url.return_value = False
 
         with patch("agent_manager.cli_extensions.config_commands.message"), pytest.raises(SystemExit):
             ConfigCommands.validate_all(config)
 
-    def test_validates_all_errors_when_no_config(self):
-        """Test that validate_all errors when config doesn't exist."""
+    def test_errors_when_no_config(self):
         config = Mock(spec=Config)
         config.exists.return_value = False
 
@@ -338,229 +178,40 @@ class TestConfigCommandsValidateAll:
             ConfigCommands.validate_all(config)
 
 
-class TestConfigCommandsExportConfig:
-    """Test cases for export_config method."""
+class TestConfigCommandsTemplate:
 
-    def test_exports_to_file(self, tmp_path):
-        """Test exporting configuration to file."""
-        output_file = tmp_path / "export.yaml"
+    def test_prints_template(self, capsys):
+        ConfigCommands.template()
+        out = capsys.readouterr().out
+        assert "repos:" in out
+        assert "directories:" in out
 
+
+class TestConfigCommandsDefaults:
+
+    def test_shows_defaults(self):
         config = Mock(spec=Config)
-        config.exists.return_value = True
-        config.read.return_value = {
-            "hierarchy": [{"name": "org", "url": "https://github.com/org/repo", "repo_type": "git", "repo": Mock()}]
+        config.get_defaults.return_value = {
+            "default_hierarchy": ["org"],
+            "default_agents": ["cursor"],
         }
-
         with patch("agent_manager.cli_extensions.config_commands.message"):
-            ConfigCommands.export_config(config, str(output_file))
+            ConfigCommands.defaults(config)
 
-        assert output_file.exists()
-
-        # Verify exported content
-        with open(output_file) as f:
-            exported = yaml.safe_load(f)
-
-        assert "hierarchy" in exported
-        assert exported["hierarchy"][0]["name"] == "org"
-        assert "repo" not in exported["hierarchy"][0]  # Should be removed
-
-    def test_exports_to_stdout(self, capsys):
-        """Test exporting configuration to stdout."""
+    def test_sets_defaults(self):
         config = Mock(spec=Config)
-        config.exists.return_value = True
-        config.read.return_value = {
-            "hierarchy": [{"name": "org", "url": "https://github.com/org/repo", "repo_type": "git", "repo": Mock()}]
-        }
-
         with patch("agent_manager.cli_extensions.config_commands.message"):
-            ConfigCommands.export_config(config, None)
-
-        captured = capsys.readouterr()
-        assert "org" in captured.out
-        assert "hierarchy" in captured.out
-
-    def test_exports_with_mergers_section(self, tmp_path):
-        """Test that export includes mergers section if present."""
-        output_file = tmp_path / "export.yaml"
-
-        config = Mock(spec=Config)
-        config.exists.return_value = True
-        config.read.return_value = {
-            "hierarchy": [{"name": "org", "url": "url", "repo_type": "git", "repo": Mock()}],
-            "mergers": {"JsonMerger": {"indent": 2}},
-        }
-
-        with patch("agent_manager.cli_extensions.config_commands.message"):
-            ConfigCommands.export_config(config, str(output_file))
-
-        with open(output_file) as f:
-            exported = yaml.safe_load(f)
-
-        assert "mergers" in exported
-        assert exported["mergers"]["JsonMerger"]["indent"] == 2
-
-    def test_export_errors_when_no_config(self):
-        """Test that export errors when config doesn't exist."""
-        config = Mock(spec=Config)
-        config.exists.return_value = False
-
-        with patch("agent_manager.cli_extensions.config_commands.message"), pytest.raises(SystemExit):
-            ConfigCommands.export_config(config, "output.yaml")
-
-
-class TestConfigCommandsImportConfig:
-    """Test cases for import_config method."""
-
-    def test_imports_from_file(self, tmp_path):
-        """Test importing configuration from file."""
-        input_file = tmp_path / "import.yaml"
-        import_data = {"hierarchy": [{"name": "org", "url": "https://github.com/org/repo", "repo_type": "git"}]}
-
-        with open(input_file, "w") as f:
-            yaml.dump(import_data, f)
-
-        config = Mock(spec=Config)
-        config.exists.return_value = False
-        config.config_file = tmp_path / "config.yaml"
-
-        with patch("agent_manager.cli_extensions.config_commands.message"):
-            ConfigCommands.import_config(config, str(input_file))
-
-        config.write.assert_called_once()
-
-    def test_import_prompts_before_overwrite(self, tmp_path):
-        """Test that import prompts before overwriting existing config."""
-        input_file = tmp_path / "import.yaml"
-        import_data = {"hierarchy": [{"name": "org", "url": "url", "repo_type": "git"}]}
-
-        with open(input_file, "w") as f:
-            yaml.dump(import_data, f)
-
-        config = Mock(spec=Config)
-        config.exists.return_value = True
-        config.config_file = tmp_path / "config.yaml"
-
-        with (
-            patch("agent_manager.cli_extensions.config_commands.message"),
-            patch("builtins.input", return_value="no"),
-        ):
-            ConfigCommands.import_config(config, str(input_file))
-
-        # Should not write if user says no
-        config.write.assert_not_called()
-
-    def test_import_handles_missing_file(self):
-        """Test that import handles missing input file."""
-        config = Mock(spec=Config)
-
-        with patch("agent_manager.cli_extensions.config_commands.message"), pytest.raises(SystemExit):
-            ConfigCommands.import_config(config, "nonexistent.yaml")
-
-    def test_import_handles_invalid_yaml(self, tmp_path):
-        """Test that import handles invalid YAML."""
-        input_file = tmp_path / "invalid.yaml"
-        input_file.write_text("invalid: yaml: content:")
-
-        config = Mock(spec=Config)
-
-        with patch("agent_manager.cli_extensions.config_commands.message"), pytest.raises(SystemExit):
-            ConfigCommands.import_config(config, str(input_file))
-
-    def test_import_validates_structure(self, tmp_path):
-        """Test that import validates configuration structure."""
-        input_file = tmp_path / "invalid.yaml"
-        with open(input_file, "w") as f:
-            yaml.dump({"not_hierarchy": []}, f)
-
-        config = Mock(spec=Config)
-
-        with patch("agent_manager.cli_extensions.config_commands.message"), pytest.raises(SystemExit):
-            ConfigCommands.import_config(config, str(input_file))
+            ConfigCommands.defaults(config, repos=["a", "b"], agents=["c"])
+        config.set_defaults.assert_called_once_with(repos=["a", "b"], agents=["c"])
 
 
 class TestConfigCommandsShowLocation:
-    """Test cases for show_location method."""
 
-    def test_shows_configuration_locations(self, tmp_path):
-        """Test that show_location displays config file locations."""
+    def test_shows_paths(self, tmp_path):
         config = Mock(spec=Config)
-
-        # Mock the path attributes and their exists() methods
-        config.config_directory = Mock()
-        config.config_directory.__str__ = Mock(return_value=str(tmp_path / "config"))
-        config.config_directory.exists = Mock(return_value=False)
-
-        config.config_file = Mock()
-        config.config_file.__str__ = Mock(return_value=str(tmp_path / "config" / "config.yaml"))
-        config.config_file.exists = Mock(return_value=False)
-
-        config.repos_directory = Mock()
-        config.repos_directory.__str__ = Mock(return_value=str(tmp_path / "config" / "repos"))
-        config.repos_directory.exists = Mock(return_value=False)
-
-        with patch("agent_manager.cli_extensions.config_commands.message"):
-            ConfigCommands.show_location(config)
-
-        # Should not raise any errors
-
-    def test_shows_existence_status(self, tmp_path):
-        """Test that show_location shows existence status."""
-        config_dir = tmp_path / "config"
-        config_dir.mkdir()
-        config_file = config_dir / "config.yaml"
-        config_file.touch()
-
-        config = Mock(spec=Config)
-        config.config_directory = config_dir
-        config.config_file = config_file
-        config.repos_directory = config_dir / "repos"
-
-        with patch("agent_manager.cli_extensions.config_commands.message"):
-            ConfigCommands.show_location(config)
-
-
-class TestConfigCommandsEdgeCases:
-    """Test cases for edge cases and special scenarios."""
-
-    def test_display_handles_unicode_names(self):
-        """Test that display handles Unicode in hierarchy names."""
-        config = Mock(spec=Config)
-        config.exists.return_value = True
-        config.read.return_value = {"hierarchy": [{"name": "组织", "url": "https://example.com", "repo_type": "git"}]}
-
-        with patch("agent_manager.cli_extensions.config_commands.message"):
-            ConfigCommands.display(config)
-
-    def test_export_handles_write_error(self, tmp_path):
-        """Test that export handles write errors."""
-        output_file = tmp_path / "readonly"
-        output_file.mkdir()  # Make it a directory to cause error
-
-        config = Mock(spec=Config)
-        config.exists.return_value = True
-        config.read.return_value = {"hierarchy": [{"name": "org", "url": "url", "repo_type": "git", "repo": Mock()}]}
-
-        with patch("agent_manager.cli_extensions.config_commands.message"), pytest.raises(SystemExit):
-            ConfigCommands.export_config(config, str(output_file))
-
-    def test_import_accepts_yes_variations(self, tmp_path):
-        """Test that import accepts various yes responses."""
-        input_file = tmp_path / "import.yaml"
-        import_data = {"hierarchy": [{"name": "org", "url": "url", "repo_type": "git"}]}
-
-        with open(input_file, "w") as f:
-            yaml.dump(import_data, f)
-
-        config = Mock(spec=Config)
-        config.exists.return_value = True
+        config.config_directory = tmp_path
         config.config_file = tmp_path / "config.yaml"
+        config.repos_directory = tmp_path / "repos"
 
-        for yes_response in ["yes", "y", "YES", "Y"]:
-            with (
-                patch("agent_manager.cli_extensions.config_commands.message"),
-                patch("builtins.input", return_value=yes_response),
-            ):
-                ConfigCommands.import_config(config, str(input_file))
-
-            config.write.assert_called()
-            config.write.reset_mock()
+        with patch("agent_manager.cli_extensions.config_commands.message"):
+            ConfigCommands.show_location(config)

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1,4 +1,4 @@
-"""Tests for config/config.py - Configuration management."""
+"""Tests for config/config.py - V2 Configuration management."""
 
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -9,100 +9,91 @@ import yaml
 from agent_manager.config.config import Config, ConfigError
 
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _minimal_config(**overrides):
+    """Return a minimal valid V2 config dict, with optional overrides."""
+    base = {
+        "repos": [
+            {"name": "org", "url": "https://github.com/org/repo", "repo_type": "git"},
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_config(config_obj: Config, data: dict) -> None:
+    """Write raw YAML data to the config file without validation."""
+    config_obj.config_directory.mkdir(parents=True, exist_ok=True)
+    with open(config_obj.config_file, "w") as f:
+        yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+
+
+# ===========================================================================
+# ConfigError
+# ===========================================================================
 class TestConfigError:
     """Test cases for ConfigError exception."""
 
     def test_single_error_message(self):
-        """Test ConfigError with single error message."""
         error = ConfigError("Single error")
-
         assert len(error.errors) == 1
         assert str(error) == "Single error"
 
     def test_multiple_error_messages(self):
-        """Test ConfigError with multiple error messages."""
         errors = ["Error 1", "Error 2", "Error 3"]
         error = ConfigError(errors)
-
         assert len(error.errors) == 3
         assert "Configuration has 3 errors" in str(error)
-        assert "Error 1" in str(error)
-        assert "Error 2" in str(error)
 
     def test_format_errors_with_list(self):
-        """Test error formatting with list of errors."""
         error = ConfigError(["First", "Second"])
-
         formatted = str(error)
         assert "2 errors" in formatted
         assert "  - First" in formatted
         assert "  - Second" in formatted
 
 
+# ===========================================================================
+# Config.__init__
+# ===========================================================================
 class TestConfigInitialization:
-    """Test cases for Config initialization."""
 
     def test_default_initialization(self):
-        """Test Config initialization with default directory."""
         config = Config()
-
         assert config.config_directory == Path.home() / ".agent-manager"
         assert config.config_file == Path.home() / ".agent-manager" / "config.yaml"
         assert config.repos_directory == Path.home() / ".agent-manager" / "repos"
 
     def test_custom_config_directory(self, tmp_path):
-        """Test Config initialization with custom directory."""
         custom_dir = tmp_path / "custom"
         config = Config(config_dir=custom_dir)
-
         assert config.config_directory == custom_dir
         assert config.config_file == custom_dir / "config.yaml"
-        assert config.repos_directory == custom_dir / "repos"
 
 
+# ===========================================================================
+# ensure_directories
+# ===========================================================================
 class TestConfigEnsureDirectories:
-    """Test cases for ensure_directories method."""
 
-    def test_creates_config_directory(self, tmp_path):
-        """Test that ensure_directories creates config directory."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-
+    def test_creates_config_and_repos_dirs(self, tmp_path):
+        config = Config(config_dir=tmp_path / "cfg")
         with patch("agent_manager.config.config.message"):
             config.ensure_directories()
+        assert config.config_directory.exists()
+        assert config.repos_directory.exists()
 
-        assert config_dir.exists()
-        assert config_dir.is_dir()
-
-    def test_creates_repos_directory(self, tmp_path):
-        """Test that ensure_directories creates repos directory."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-
+    def test_idempotent(self, tmp_path):
+        config = Config(config_dir=tmp_path / "cfg")
         with patch("agent_manager.config.config.message"):
             config.ensure_directories()
-
-        repos_dir = config_dir / "repos"
-        assert repos_dir.exists()
-        assert repos_dir.is_dir()
-
-    def test_idempotent_creation(self, tmp_path):
-        """Test that ensure_directories is idempotent."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-
-        with patch("agent_manager.config.config.message"):
             config.ensure_directories()
-            config.ensure_directories()  # Call again
-
-        # Should not raise error
-        assert config_dir.exists()
+        assert config.config_directory.exists()
 
     def test_handles_permission_error(self, tmp_path):
-        """Test that ensure_directories handles permission errors."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-
+        config = Config(config_dir=tmp_path / "cfg")
         with (
             patch("pathlib.Path.mkdir", side_effect=PermissionError),
             patch("agent_manager.config.config.message"),
@@ -111,10 +102,7 @@ class TestConfigEnsureDirectories:
             config.ensure_directories()
 
     def test_handles_os_error(self, tmp_path):
-        """Test that ensure_directories handles OS errors."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-
+        config = Config(config_dir=tmp_path / "cfg")
         with (
             patch("pathlib.Path.mkdir", side_effect=OSError("Disk full")),
             patch("agent_manager.config.config.message"),
@@ -123,941 +111,576 @@ class TestConfigEnsureDirectories:
             config.ensure_directories()
 
     def test_handles_generic_exception(self, tmp_path):
-        """Test that ensure_directories handles unexpected exceptions."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-
+        config = Config(config_dir=tmp_path / "cfg")
         with (
-            patch("pathlib.Path.mkdir", side_effect=RuntimeError("Unexpected error")),
+            patch("pathlib.Path.mkdir", side_effect=RuntimeError("oops")),
             patch("agent_manager.config.config.message"),
             pytest.raises(SystemExit),
         ):
             config.ensure_directories()
 
 
-class TestConfigValidateRepoUrl:
-    """Test cases for validate_repo_url static method."""
-
-    @patch("agent_manager.config.config.discover_repo_types")
-    def test_validates_git_url(self, mock_discover):
-        """Test validation of git URL."""
-        from agent_manager.plugins.repos.git_repo import GitRepo
-
-        mock_git_repo = Mock(spec=GitRepo)
-        mock_git_repo.REPO_TYPE = "git"
-        mock_git_repo.can_handle_url.return_value = True
-        mock_git_repo.validate_url.return_value = True
-
-        mock_discover.return_value = [mock_git_repo]
-
-        with patch("agent_manager.config.config.message"):
-            result = Config.validate_repo_url("https://github.com/user/repo")
-
-        assert result is True
-
-    @patch("agent_manager.config.config.discover_repo_types")
-    def test_validates_file_url(self, mock_discover):
-        """Test validation of file URL."""
-        from agent_manager.plugins.repos.local_repo import LocalRepo
-
-        mock_local_repo = Mock(spec=LocalRepo)
-        mock_local_repo.REPO_TYPE = "file"
-        mock_local_repo.can_handle_url.return_value = True
-        mock_local_repo.validate_url.return_value = True
-
-        mock_discover.return_value = [mock_local_repo]
-
-        with patch("agent_manager.config.config.message"):
-            result = Config.validate_repo_url("file:///tmp/repo")
-
-        assert result is True
-
-    @patch("agent_manager.config.config.Config.detect_repo_types")
-    def test_rejects_invalid_url(self, mock_detect):
-        """Test rejection of invalid URL."""
-        mock_detect.return_value = []
-
-        with patch("agent_manager.config.config.message"):
-            result = Config.validate_repo_url("invalid://url")
-
-        assert result is False
-
-
-class TestConfigValidateRepoUrlEdgeCases:
-    """Test edge cases for validate_repo_url."""
-
-    def test_validate_url_with_missing_repo_class(self):
-        """Test validate_url when repo class is not found after detection."""
-        url = "https://github.com/test/repo"
-
-        # Mock detect_repo_types to return a type, but discover_repo_types to return empty
-        with (
-            patch("agent_manager.config.config.Config.detect_repo_types", return_value=["nonexistent"]),
-            patch("agent_manager.config.config.discover_repo_types", return_value=[]),
-            patch("agent_manager.config.config.message"),
-        ):
-            result = Config.validate_repo_url(url)
-
-            # Should return False and log internal error
-            assert result is False
-
-
-class TestConfigDetectRepoTypes:
-    """Test cases for detect_repo_types static method."""
-
-    @patch("agent_manager.config.config.discover_repo_types")
-    def test_detects_single_type(self, mock_discover):
-        """Test detection of single matching repo type."""
-        mock_repo = Mock()
-        mock_repo.REPO_TYPE = "git"
-        mock_repo.can_handle_url.return_value = True
-
-        mock_discover.return_value = [mock_repo]
-
-        types = Config.detect_repo_types("https://github.com/user/repo")
-
-        assert types == ["git"]
-
-    @patch("agent_manager.config.config.discover_repo_types")
-    def test_detects_multiple_types(self, mock_discover):
-        """Test detection of multiple matching repo types."""
-        mock_repo1 = Mock()
-        mock_repo1.REPO_TYPE = "type1"
-        mock_repo1.can_handle_url.return_value = True
-
-        mock_repo2 = Mock()
-        mock_repo2.REPO_TYPE = "type2"
-        mock_repo2.can_handle_url.return_value = True
-
-        mock_discover.return_value = [mock_repo1, mock_repo2]
-
-        types = Config.detect_repo_types("https://example.com")
-
-        assert "type1" in types
-        assert "type2" in types
-
-    @patch("agent_manager.config.config.discover_repo_types")
-    def test_detects_no_types(self, mock_discover):
-        """Test detection when no types match."""
-        mock_repo = Mock()
-        mock_repo.can_handle_url.return_value = False
-
-        mock_discover.return_value = [mock_repo]
-
-        types = Config.detect_repo_types("invalid://url")
-
-        assert types == []
-
-
-class TestConfigPromptForRepoType:
-    """Test cases for prompt_for_repo_type static method."""
-
-    @patch("builtins.input", return_value="1")
-    def test_prompts_and_returns_selection(self, mock_input):
-        """Test that prompt returns selected repo type."""
-        url = "https://example.com"
-        available = ["git", "file"]
-
-        with patch("agent_manager.config.config.message"):
-            selected = Config.prompt_for_repo_type(url, available)
-
-        assert selected == "git"
-
-    @patch("builtins.input", return_value="2")
-    def test_prompts_returns_second_option(self, mock_input):
-        """Test selection of second option."""
-        available = ["type1", "type2", "type3"]
-
-        with patch("agent_manager.config.config.message"):
-            selected = Config.prompt_for_repo_type("url", available)
-
-        assert selected == "type2"
-
-    @patch("builtins.input", side_effect=["invalid", "0", "5", "2"])
-    def test_prompts_retries_on_invalid_input(self, mock_input):
-        """Test that prompt retries on invalid input."""
-        available = ["type1", "type2"]
-
-        with patch("agent_manager.config.config.message"):
-            selected = Config.prompt_for_repo_type("url", available)
-
-        # Should eventually select type2
-        assert selected == "type2"
-        assert mock_input.call_count == 4
-
-
-class TestConfigValidate:
-    """Test cases for validate static method."""
-
-    def test_validates_valid_config(self):
-        """Test validation of valid configuration."""
-        config = {
-            "hierarchy": [
-                {"name": "org", "url": "https://github.com/org/repo", "repo_type": "git"},
-                {"name": "team", "url": "file:///tmp/team", "repo_type": "file"},
-            ]
-        }
-
-        # Should not raise exception
-        Config.validate(config)
-
-    def test_rejects_missing_hierarchy(self):
-        """Test rejection of config without hierarchy key."""
-        config = {}
-
-        with pytest.raises(ConfigError) as exc_info:
-            Config.validate(config)
-
-        assert "must contain 'hierarchy' key" in str(exc_info.value)
-
-    def test_rejects_non_list_hierarchy(self):
-        """Test rejection of hierarchy that's not a list."""
-        config = {"hierarchy": "not a list"}
-
-        with pytest.raises(ConfigError) as exc_info:
-            Config.validate(config)
-
-        assert "'hierarchy' must be a list" in str(exc_info.value)
-
-    def test_rejects_empty_hierarchy(self):
-        """Test rejection of empty hierarchy."""
-        config = {"hierarchy": []}
-
-        with pytest.raises(ConfigError) as exc_info:
-            Config.validate(config)
-
-        assert "'hierarchy' cannot be empty" in str(exc_info.value)
-
-    def test_rejects_non_dict_entry(self):
-        """Test rejection of non-dictionary hierarchy entry."""
-        config = {"hierarchy": ["not a dict"]}
-
-        with pytest.raises(ConfigError) as exc_info:
-            Config.validate(config)
-
-        assert "must be a dictionary" in str(exc_info.value)
-
-    def test_rejects_missing_required_keys(self):
-        """Test rejection of entry missing required keys."""
-        config = {"hierarchy": [{"name": "org"}]}  # Missing url and repo_type
-
-        with pytest.raises(ConfigError) as exc_info:
-            Config.validate(config)
-
-        error_str = str(exc_info.value)
-        assert "missing required keys" in error_str
-        assert "url" in error_str
-        assert "repo_type" in error_str
-
-    def test_rejects_non_string_name(self):
-        """Test rejection of non-string name field."""
-        config = {"hierarchy": [{"name": 123, "url": "url", "repo_type": "git"}]}
-
-        with pytest.raises(ConfigError) as exc_info:
-            Config.validate(config)
-
-        assert "'name' must be a string" in str(exc_info.value)
-
-    def test_rejects_empty_name(self):
-        """Test rejection of empty name field."""
-        config = {"hierarchy": [{"name": "", "url": "url", "repo_type": "git"}]}
-
-        with pytest.raises(ConfigError) as exc_info:
-            Config.validate(config)
-
-        assert "'name' cannot be empty" in str(exc_info.value)
-
-    def test_rejects_non_string_url(self):
-        """Test rejection of non-string url field."""
-        config = {"hierarchy": [{"name": "org", "url": 456, "repo_type": "git"}]}
-
-        with pytest.raises(ConfigError) as exc_info:
-            Config.validate(config)
-
-        assert "'url' must be a string" in str(exc_info.value)
-
-    def test_rejects_empty_url(self):
-        """Test rejection of empty url field."""
-        config = {"hierarchy": [{"name": "org", "url": "", "repo_type": "git"}]}
-
-        with pytest.raises(ConfigError) as exc_info:
-            Config.validate(config)
-
-        assert "'url' cannot be empty" in str(exc_info.value)
-
-    def test_rejects_non_string_repo_type(self):
-        """Test rejection of non-string repo_type field."""
-        config = {"hierarchy": [{"name": "org", "url": "url", "repo_type": 789}]}
-
-        with pytest.raises(ConfigError) as exc_info:
-            Config.validate(config)
-
-        assert "'repo_type' must be a string" in str(exc_info.value)
-
-    def test_rejects_empty_repo_type(self):
-        """Test rejection of empty repo_type field."""
-        config = {"hierarchy": [{"name": "org", "url": "url", "repo_type": ""}]}
-
-        with pytest.raises(ConfigError) as exc_info:
-            Config.validate(config)
-
-        assert "'repo_type' cannot be empty" in str(exc_info.value)
+# ===========================================================================
+# validate – repos
+# ===========================================================================
+class TestValidateRepos:
+
+    def test_valid_minimal_config(self):
+        Config.validate(_minimal_config())
+
+    def test_missing_repos_key(self):
+        with pytest.raises(ConfigError, match="must contain 'repos' key"):
+            Config.validate({})
+
+    def test_repos_not_a_list(self):
+        with pytest.raises(ConfigError, match="'repos' must be a list"):
+            Config.validate({"repos": "bad"})
+
+    def test_repo_entry_not_dict(self):
+        with pytest.raises(ConfigError, match="must be a dictionary"):
+            Config.validate({"repos": ["bad"]})
+
+    def test_repo_missing_required_keys(self):
+        with pytest.raises(ConfigError, match="missing required keys"):
+            Config.validate({"repos": [{"name": "x"}]})
+
+    def test_repo_name_not_string(self):
+        with pytest.raises(ConfigError, match="'name' must be a string"):
+            Config.validate({"repos": [{"name": 123, "url": "u", "repo_type": "git"}]})
+
+    def test_repo_name_empty(self):
+        with pytest.raises(ConfigError, match="'name' cannot be empty"):
+            Config.validate({"repos": [{"name": "", "url": "u", "repo_type": "git"}]})
+
+    def test_repo_duplicate_name(self):
+        with pytest.raises(ConfigError, match="duplicate name"):
+            Config.validate({
+                "repos": [
+                    {"name": "dup", "url": "u1", "repo_type": "git"},
+                    {"name": "dup", "url": "u2", "repo_type": "git"},
+                ]
+            })
+
+    def test_repo_url_not_string(self):
+        with pytest.raises(ConfigError, match="'url' must be a string"):
+            Config.validate({"repos": [{"name": "x", "url": 123, "repo_type": "git"}]})
+
+    def test_repo_url_empty(self):
+        with pytest.raises(ConfigError, match="'url' cannot be empty"):
+            Config.validate({"repos": [{"name": "x", "url": "", "repo_type": "git"}]})
+
+    def test_repo_type_not_string(self):
+        with pytest.raises(ConfigError, match="'repo_type' must be a string"):
+            Config.validate({"repos": [{"name": "x", "url": "u", "repo_type": 9}]})
+
+    def test_repo_type_empty(self):
+        with pytest.raises(ConfigError, match="'repo_type' cannot be empty"):
+            Config.validate({"repos": [{"name": "x", "url": "u", "repo_type": ""}]})
 
     def test_collects_multiple_errors(self):
-        """Test that validation collects multiple errors."""
-        config = {
-            "hierarchy": [
-                {"name": "", "url": "", "repo_type": ""},  # 3 errors
-                {"name": 123, "url": 456, "repo_type": 789},  # 3 errors
-            ]
-        }
-
-        with pytest.raises(ConfigError) as exc_info:
-            Config.validate(config)
-
-        error_str = str(exc_info.value)
-        assert "6 errors" in error_str or "cannot be empty" in error_str
+        with pytest.raises(ConfigError) as exc:
+            Config.validate({
+                "repos": [
+                    {"name": "", "url": "", "repo_type": ""},
+                    {"name": 1, "url": 2, "repo_type": 3},
+                ]
+            })
+        assert len(exc.value.errors) >= 4
 
 
-class TestConfigWrite:
-    """Test cases for write method."""
+# ===========================================================================
+# validate – default_hierarchy
+# ===========================================================================
+class TestValidateDefaultHierarchy:
 
-    def test_writes_valid_config(self, tmp_path):
-        """Test writing valid configuration."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config_dir.mkdir()
+    def test_valid_default_hierarchy(self):
+        Config.validate(_minimal_config(default_hierarchy=["org"]))
 
-        config_data = {"hierarchy": [{"name": "org", "url": "https://github.com/org/repo", "repo_type": "git"}]}
+    def test_default_hierarchy_not_list(self):
+        with pytest.raises(ConfigError, match="'default_hierarchy' must be a list"):
+            Config.validate(_minimal_config(default_hierarchy="bad"))
 
+    def test_default_hierarchy_entry_not_string(self):
+        with pytest.raises(ConfigError, match="default_hierarchy entry 0 must be a string"):
+            Config.validate(_minimal_config(default_hierarchy=[123]))
+
+    def test_default_hierarchy_references_unknown_repo(self):
+        with pytest.raises(ConfigError, match="does not match any repo name"):
+            Config.validate(_minimal_config(default_hierarchy=["nonexistent"]))
+
+
+# ===========================================================================
+# validate – default_agents
+# ===========================================================================
+class TestValidateDefaultAgents:
+
+    def test_valid_default_agents(self):
+        Config.validate(_minimal_config(default_agents=["cursor", "claude"]))
+
+    def test_default_agents_not_list(self):
+        with pytest.raises(ConfigError, match="'default_agents' must be a list"):
+            Config.validate(_minimal_config(default_agents="bad"))
+
+    def test_default_agents_entry_not_string(self):
+        with pytest.raises(ConfigError, match="default_agents entry 0 must be a string"):
+            Config.validate(_minimal_config(default_agents=[99]))
+
+    def test_default_agents_entry_empty(self):
+        with pytest.raises(ConfigError, match="default_agents entry 0 cannot be empty"):
+            Config.validate(_minimal_config(default_agents=[""]))
+
+
+# ===========================================================================
+# validate – directories
+# ===========================================================================
+class TestValidateDirectories:
+
+    def test_valid_directories(self):
+        Config.validate(_minimal_config(
+            default_hierarchy=["org"],
+            directories={"HOME": {"type": "local", "agents": ["cursor"], "hierarchy": ["org"]}},
+        ))
+
+    def test_directories_not_dict(self):
+        with pytest.raises(ConfigError, match="'directories' must be a dictionary"):
+            Config.validate(_minimal_config(directories="bad"))
+
+    def test_directory_config_not_dict(self):
+        with pytest.raises(ConfigError, match="config must be a dictionary"):
+            Config.validate(_minimal_config(directories={"HOME": "bad"}))
+
+    def test_directory_none_value_accepted(self):
+        """A directory with None (bare key in YAML) is valid."""
+        Config.validate(_minimal_config(
+            default_hierarchy=["org"],
+            directories={"HOME": None},
+        ))
+
+    def test_directory_type_not_string(self):
+        with pytest.raises(ConfigError, match="'type' must be a string"):
+            Config.validate(_minimal_config(directories={"HOME": {"type": 123}}))
+
+    def test_directory_type_empty(self):
+        with pytest.raises(ConfigError, match="'type' cannot be empty"):
+            Config.validate(_minimal_config(directories={"HOME": {"type": ""}}))
+
+    def test_directory_agents_not_list(self):
+        with pytest.raises(ConfigError, match="'agents' must be a list"):
+            Config.validate(_minimal_config(directories={"HOME": {"agents": "bad"}}))
+
+    def test_directory_agents_entry_not_string(self):
+        with pytest.raises(ConfigError, match="agents entry 0 must be a string"):
+            Config.validate(_minimal_config(directories={"HOME": {"agents": [42]}}))
+
+    def test_directory_hierarchy_not_list(self):
+        with pytest.raises(ConfigError, match="'hierarchy' must be a list"):
+            Config.validate(_minimal_config(directories={"HOME": {"hierarchy": "bad"}}))
+
+    def test_directory_hierarchy_entry_not_string(self):
+        with pytest.raises(ConfigError, match="hierarchy entry 0 must be a string"):
+            Config.validate(_minimal_config(directories={"HOME": {"hierarchy": [42]}}))
+
+    def test_directory_hierarchy_references_unknown_repo(self):
+        with pytest.raises(ConfigError, match="does not match any repo name"):
+            Config.validate(_minimal_config(directories={"HOME": {"hierarchy": ["ghost"]}}))
+
+    def test_warns_when_no_hierarchy_and_no_default(self):
+        """Should warn when directory omits hierarchy and no default_hierarchy."""
+        warnings = Config.validate(_minimal_config(directories={"HOME": {}}))
+        assert any("no repos will be merged" in w for w in warnings)
+
+    def test_no_warning_when_directory_has_hierarchy(self):
+        warnings = Config.validate(_minimal_config(directories={"HOME": {"hierarchy": ["org"]}}))
+        assert len(warnings) == 0
+
+    def test_no_warning_when_default_hierarchy_set(self):
+        warnings = Config.validate(_minimal_config(
+            default_hierarchy=["org"],
+            directories={"HOME": {}},
+        ))
+        assert len(warnings) == 0
+
+
+# ===========================================================================
+# validate – extra fields
+# ===========================================================================
+class TestValidateExtraFields:
+
+    def test_allows_additional_top_level_keys(self):
+        cfg = _minimal_config()
+        cfg["mergers"] = {"JsonMerger": {"indent": 2}}
+        Config.validate(cfg)
+
+    def test_allows_extra_keys_in_repo_entry(self):
+        cfg = _minimal_config()
+        cfg["repos"][0]["extra"] = "val"
+        Config.validate(cfg)
+
+
+# ===========================================================================
+# write / read round-trip
+# ===========================================================================
+class TestConfigWriteRead:
+
+    def test_write_and_read_minimal(self, tmp_path):
+        config = Config(config_dir=tmp_path / "cfg")
+        config.config_directory.mkdir(parents=True)
+
+        data = _minimal_config()
         with patch("agent_manager.config.config.message"):
-            config.write(config_data)
+            config.write(data)
 
         assert config.config_file.exists()
 
-        # Verify contents
-        with open(config.config_file) as f:
-            written = yaml.safe_load(f)
-
-        assert written["hierarchy"][0]["name"] == "org"
-
-    def test_write_rejects_invalid_config(self, tmp_path):
-        """Test that write rejects invalid configuration."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config_dir.mkdir()
-
-        invalid_config = {"hierarchy": []}  # Empty hierarchy
-
-        with pytest.raises(SystemExit):
-            config.write(invalid_config)
-
-    def test_write_handles_os_error(self, tmp_path):
-        """Test that write handles file system errors."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        # Don't create directory to cause error
-
-        config_data = {"hierarchy": [{"name": "org", "url": "https://github.com/org/repo", "repo_type": "git"}]}
-
-        with pytest.raises(SystemExit):
-            config.write(config_data)
-
-    def test_write_handles_generic_exception(self, tmp_path):
-        """Test that write handles unexpected exceptions."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config_dir.mkdir()
-
-        config_data = {"hierarchy": [{"name": "org", "url": "https://github.com/org/repo", "repo_type": "git"}]}
-
-        # Simulate unexpected exception during YAML dump
-        with patch("yaml.dump", side_effect=RuntimeError("Unexpected error")), pytest.raises(SystemExit):
-            config.write(config_data)
-
-
-class TestConfigRead:
-    """Test cases for read method."""
-
-    def test_reads_valid_config(self, tmp_path):
-        """Test reading valid configuration file."""
-        config_dir = tmp_path / "config"
-        config_dir.mkdir()
-
-        config_file = config_dir / "config.yaml"
-        config_data = {"hierarchy": [{"name": "org", "url": "https://github.com/org/repo", "repo_type": "git"}]}
-
-        with open(config_file, "w") as f:
-            yaml.dump(config_data, f)
-
-        config = Config(config_dir=config_dir)
-
         with (
             patch("agent_manager.config.config.message"),
-            patch("agent_manager.config.config.create_repo") as mock_create,
+            patch("agent_manager.config.config.create_repo", return_value=Mock()),
         ):
-            mock_create.return_value = Mock()
             loaded = config.read()
 
-        assert loaded["hierarchy"][0]["name"] == "org"
-        assert "repo" in loaded["hierarchy"][0]
+        assert loaded["repos"][0]["name"] == "org"
+
+    def test_write_full_config(self, tmp_path):
+        config = Config(config_dir=tmp_path / "cfg")
+        config.config_directory.mkdir(parents=True)
+
+        data = _minimal_config(
+            default_hierarchy=["org"],
+            default_agents=["cursor"],
+            directories={"HOME": {"type": "local", "agents": ["cursor"], "hierarchy": ["org"]}},
+        )
+
+        with patch("agent_manager.config.config.message"):
+            config.write(data)
+
+        with open(config.config_file) as f:
+            raw = yaml.safe_load(f)
+
+        assert raw["default_hierarchy"] == ["org"]
+        assert raw["default_agents"] == ["cursor"]
+        assert raw["directories"]["HOME"]["type"] == "local"
+
+    def test_write_rejects_invalid_config(self, tmp_path):
+        config = Config(config_dir=tmp_path / "cfg")
+        config.config_directory.mkdir(parents=True)
+
+        with pytest.raises(SystemExit):
+            config.write({})  # Missing repos key entirely
+
+    def test_write_handles_os_error(self, tmp_path):
+        config = Config(config_dir=tmp_path / "nonexistent")
+        with pytest.raises(SystemExit):
+            config.write(_minimal_config())
 
     def test_read_handles_missing_file(self, tmp_path):
-        """Test that read handles missing configuration file."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-
+        config = Config(config_dir=tmp_path / "cfg")
         with patch("agent_manager.config.config.message"), pytest.raises(SystemExit):
             config.read()
 
     def test_read_handles_empty_file(self, tmp_path):
-        """Test that read handles empty configuration file."""
-        config_dir = tmp_path / "config"
-        config_dir.mkdir()
-
-        config_file = config_dir / "config.yaml"
-        config_file.touch()  # Create empty file
-
-        config = Config(config_dir=config_dir)
-
+        config = Config(config_dir=tmp_path / "cfg")
+        config.config_directory.mkdir(parents=True)
+        config.config_file.touch()
         with patch("agent_manager.config.config.message"), pytest.raises(SystemExit):
             config.read()
 
-    def test_read_handles_invalid_config(self, tmp_path):
-        """Test that read handles invalid configuration."""
-        config_dir = tmp_path / "config"
-        config_dir.mkdir()
-
-        config_file = config_dir / "config.yaml"
-        with open(config_file, "w") as f:
-            yaml.dump({"hierarchy": []}, f)  # Invalid (empty)
-
-        config = Config(config_dir=config_dir)
-
+    def test_read_handles_invalid_yaml(self, tmp_path):
+        config = Config(config_dir=tmp_path / "cfg")
+        config.config_directory.mkdir(parents=True)
+        config.config_file.write_text("invalid: yaml: content: [")
         with patch("agent_manager.config.config.message"), pytest.raises(SystemExit):
             config.read()
 
 
+# ===========================================================================
+# exists
+# ===========================================================================
 class TestConfigExists:
-    """Test cases for exists method."""
 
-    def test_exists_returns_true_when_file_exists(self, tmp_path):
-        """Test that exists returns True when config file exists."""
-        config_dir = tmp_path / "config"
-        config_dir.mkdir()
-
-        config_file = config_dir / "config.yaml"
-        config_file.touch()
-
-        config = Config(config_dir=config_dir)
-
+    def test_returns_true_when_exists(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        (tmp_path / "config.yaml").touch()
         assert config.exists() is True
 
-    def test_exists_returns_false_when_file_missing(self, tmp_path):
-        """Test that exists returns False when config file doesn't exist."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-
+    def test_returns_false_when_missing(self, tmp_path):
+        config = Config(config_dir=tmp_path / "nonexistent")
         assert config.exists() is False
 
 
-class TestConfigInitialize:
-    """Test cases for initialize method."""
+# ===========================================================================
+# get_repo_names / get_directory_paths
+# ===========================================================================
+class TestConfigGetters:
 
-    def test_initialize_creates_config(self, tmp_path):
-        """Test that initialize creates configuration."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
+    def test_get_repo_names(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        _write_config(config, _minimal_config())
+        assert config.get_repo_names() == ["org"]
 
-        # Ensure directories exist
-        config.ensure_directories()
+    def test_get_repo_names_empty(self, tmp_path):
+        config = Config(config_dir=tmp_path / "x")
+        assert config.get_repo_names() == []
+
+    def test_get_directory_paths(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        _write_config(config, _minimal_config(directories={"HOME": None, "/x": {}}))
+        paths = config.get_directory_paths()
+        assert "HOME" in paths
+        assert "/x" in paths
+
+    def test_get_directory_paths_empty(self, tmp_path):
+        config = Config(config_dir=tmp_path / "x")
+        assert config.get_directory_paths() == []
+
+
+# ===========================================================================
+# add_repo
+# ===========================================================================
+class TestAddRepo:
+
+    def test_adds_repo(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        _write_config(config, _minimal_config())
 
         with (
             patch("agent_manager.config.config.message"),
-            patch("builtins.input", side_effect=['["org"]', "https://github.com/org/repo"]),
+            patch("agent_manager.config.config.create_repo", return_value=Mock()),
+            patch("agent_manager.config.config.Config.detect_repo_types", return_value=["file"]),
             patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
-            patch("agent_manager.config.config.Config.detect_repo_types", return_value=["git"]),
         ):
-            config.initialize()
+            config.add_repo("personal", "file:///tmp/personal")
 
-        assert config_dir.exists()
-        assert config.config_file.exists()
+        with open(config.config_file) as f:
+            raw = yaml.safe_load(f)
+        names = [r["name"] for r in raw["repos"]]
+        assert "personal" in names
 
-    def test_initialize_skips_if_exists(self, tmp_path):
-        """Test that initialize skips if config already exists."""
-        config_dir = tmp_path / "config"
-        config_dir.mkdir()
-
-        config_file = config_dir / "config.yaml"
-        config_file.touch()
-
-        config = Config(config_dir=config_dir)
-
-        with patch("agent_manager.config.config.message"):
-            config.initialize(skip_if_already_created=True)
-
-        # Should not prompt for input
-
-    def test_initialize_cancelled_on_overwrite_no(self, tmp_path):
-        """Test that initialize can be cancelled when overwriting."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
-        config.config_file.touch()  # Create existing file
+    def test_rejects_duplicate_name(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        _write_config(config, _minimal_config())
 
         with (
             patch("agent_manager.config.config.message"),
-            patch("builtins.input", return_value="no"),  # Say no to overwrite
-        ):
-            config.initialize(skip_if_already_created=False)
-
-        # File should still exist but not be modified (just touched, so empty)
-        assert config.config_file.exists()
-        assert config.config_file.stat().st_size == 0
-
-    def test_initialize_continues_on_overwrite_yes(self, tmp_path):
-        """Test that initialize continues when user confirms overwrite."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
-        config.config_file.touch()  # Create existing file
-
-        with (
-            patch("agent_manager.config.config.message"),
-            patch("builtins.input", side_effect=["yes", '["org"]', "https://github.com/org/repo"]),
+            patch("agent_manager.config.config.create_repo", return_value=Mock()),
             patch("agent_manager.config.config.Config.detect_repo_types", return_value=["git"]),
             patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
+            pytest.raises(SystemExit),
         ):
-            config.initialize(skip_if_already_created=False)
+            config.add_repo("org", "https://other.com")
 
-        # Config file should be updated with content
-        assert config.config_file.exists()
-        assert config.config_file.stat().st_size > 0
+    def test_rejects_when_no_config(self, tmp_path):
+        config = Config(config_dir=tmp_path / "x")
+        with patch("agent_manager.config.config.message"), pytest.raises(SystemExit):
+            config.add_repo("a", "u")
 
-    def test_initialize_hierarchy_not_a_list_retry(self, tmp_path):
-        """Test that initialize retries when hierarchy is not a list."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
+
+# ===========================================================================
+# remove_repo
+# ===========================================================================
+class TestRemoveRepo:
+
+    def test_removes_repo(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        data = _minimal_config()
+        data["repos"].append({"name": "extra", "url": "u", "repo_type": "git"})
+        _write_config(config, data)
 
         with (
             patch("agent_manager.config.config.message"),
-            patch(
-                "builtins.input",
-                side_effect=['{"key": "value"}', '["org"]', "https://github.com/org/repo"],
-            ),
-            patch("agent_manager.config.config.Config.detect_repo_types", return_value=["git"]),
-            patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
+            patch("agent_manager.config.config.create_repo", return_value=Mock()),
         ):
-            config.initialize()
+            config.remove_repo("extra")
 
-        assert config.config_file.exists()
+        with open(config.config_file) as f:
+            raw = yaml.safe_load(f)
+        names = [r["name"] for r in raw["repos"]]
+        assert "extra" not in names
 
-    def test_initialize_hierarchy_syntax_error_retry(self, tmp_path):
-        """Test that initialize retries on syntax error in hierarchy."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
+    def test_refuses_if_referenced_without_force(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        _write_config(config, _minimal_config(default_hierarchy=["org"]))
 
         with (
             patch("agent_manager.config.config.message"),
-            patch(
-                "builtins.input",
-                side_effect=["[invalid", '["org"]', "https://github.com/org/repo"],
-            ),
-            patch("agent_manager.config.config.Config.detect_repo_types", return_value=["git"]),
-            patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
+            patch("agent_manager.config.config.create_repo", return_value=Mock()),
+            pytest.raises(SystemExit),
         ):
-            config.initialize()
+            config.remove_repo("org", force=False)
 
-        assert config.config_file.exists()
-
-    def test_initialize_empty_url_retry(self, tmp_path):
-        """Test that initialize retries when URL is empty."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
+    def test_cascades_with_force(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        _write_config(config, _minimal_config(
+            default_hierarchy=["org"],
+            directories={"HOME": {"hierarchy": ["org"]}},
+        ))
 
         with (
             patch("agent_manager.config.config.message"),
-            patch(
-                "builtins.input",
-                side_effect=['["org"]', "", "https://github.com/org/repo"],
-            ),
-            patch("agent_manager.config.config.Config.detect_repo_types", return_value=["git"]),
-            patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
+            patch("agent_manager.config.config.create_repo", return_value=Mock()),
         ):
-            config.initialize()
+            config.remove_repo("org", force=True)
 
-        assert config.config_file.exists()
+        with open(config.config_file) as f:
+            raw = yaml.safe_load(f)
+        assert raw["repos"] == []
+        assert raw["default_hierarchy"] == []
 
-    def test_initialize_no_matching_repo_type_retry(self, tmp_path):
-        """Test that initialize retries when no repo type matches URL."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
+    def test_not_found(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        _write_config(config, _minimal_config())
+        with (
+            patch("agent_manager.config.config.message"),
+            patch("agent_manager.config.config.create_repo", return_value=Mock()),
+            pytest.raises(SystemExit),
+        ):
+            config.remove_repo("ghost")
+
+
+# ===========================================================================
+# add_directory / remove_directory
+# ===========================================================================
+class TestDirectoryManagement:
+
+    def test_add_directory(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        _write_config(config, _minimal_config(default_hierarchy=["org"]))
 
         with (
             patch("agent_manager.config.config.message"),
-            patch(
-                "builtins.input",
-                side_effect=['["org"]', "invalid://bad", "https://github.com/org/repo"],
-            ),
-            # First call returns empty, second returns git, then one more for validation
-            patch(
-                "agent_manager.config.config.Config.detect_repo_types",
-                side_effect=[[], ["git"]],
-            ),
-            patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
+            patch("agent_manager.config.config.create_repo", return_value=Mock()),
         ):
-            config.initialize()
+            config.add_directory("HOME", dir_type="local", agents=["cursor"])
 
-        assert config.config_file.exists()
+        with open(config.config_file) as f:
+            raw = yaml.safe_load(f)
+        assert "HOME" in raw["directories"]
+        assert raw["directories"]["HOME"]["type"] == "local"
 
-    def test_initialize_accepts_comma_separated_hierarchy(self, tmp_path):
-        """Test that initialize accepts comma-separated hierarchy levels."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
+    def test_add_directory_duplicate(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        _write_config(config, _minimal_config(directories={"HOME": None}))
+        with (
+            patch("agent_manager.config.config.message"),
+            patch("agent_manager.config.config.create_repo", return_value=Mock()),
+            pytest.raises(SystemExit),
+        ):
+            config.add_directory("HOME")
+
+    def test_remove_directory(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        _write_config(config, _minimal_config(
+            default_hierarchy=["org"],
+            directories={"HOME": None, "/x": None},
+        ))
 
         with (
             patch("agent_manager.config.config.message"),
-            patch(
-                "builtins.input",
-                side_effect=["org, team, personal", "url1", "url2", "url3"],
-            ),
-            patch("agent_manager.config.config.Config.detect_repo_types", return_value=["git"]),
-            patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
+            patch("agent_manager.config.config.create_repo", return_value=Mock()),
         ):
-            config.initialize()
+            config.remove_directory("HOME")
 
-        # Verify the hierarchy was parsed correctly
-        data = config.read()
-        assert len(data["hierarchy"]) == 3
-        assert data["hierarchy"][0]["name"] == "org"
-        assert data["hierarchy"][1]["name"] == "team"
-        assert data["hierarchy"][2]["name"] == "personal"
+        with open(config.config_file) as f:
+            raw = yaml.safe_load(f)
+        assert "HOME" not in raw["directories"]
 
-    def test_initialize_strips_whitespace_from_hierarchy(self, tmp_path):
-        """Test that initialize strips whitespace from comma-separated levels."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
+    def test_remove_directory_not_found(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        _write_config(config, _minimal_config())
+        with (
+            patch("agent_manager.config.config.message"),
+            patch("agent_manager.config.config.create_repo", return_value=Mock()),
+            pytest.raises(SystemExit),
+        ):
+            config.remove_directory("ghost")
+
+
+# ===========================================================================
+# set_defaults / get_defaults
+# ===========================================================================
+class TestDefaults:
+
+    def test_set_and_get_defaults(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        _write_config(config, _minimal_config())
 
         with (
             patch("agent_manager.config.config.message"),
-            patch(
-                "builtins.input",
-                side_effect=["  org  ,  team  ", "url1", "url2"],
-            ),
-            patch("agent_manager.config.config.Config.detect_repo_types", return_value=["git"]),
-            patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
+            patch("agent_manager.config.config.create_repo", return_value=Mock()),
         ):
-            config.initialize()
+            config.set_defaults(repos=["org"], agents=["cursor"])
 
-        data = config.read()
-        assert data["hierarchy"][0]["name"] == "org"
-        assert data["hierarchy"][1]["name"] == "team"
+        defaults = config.get_defaults()
+        assert defaults["default_hierarchy"] == ["org"]
+        assert defaults["default_agents"] == ["cursor"]
 
-    def test_initialize_accepts_python_list_syntax(self, tmp_path):
-        """Test that initialize still accepts Python list syntax for backward compatibility."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
-
-        with (
-            patch("agent_manager.config.config.message"),
-            patch("builtins.input", side_effect=['["org", "team"]', "url1", "url2"]),
-            patch("agent_manager.config.config.Config.detect_repo_types", return_value=["git"]),
-            patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
-        ):
-            config.initialize()
-
-        data = config.read()
-        assert len(data["hierarchy"]) == 2
-        assert data["hierarchy"][0]["name"] == "org"
-        assert data["hierarchy"][1]["name"] == "team"
-
-    def test_initialize_rejects_empty_hierarchy_entries(self, tmp_path):
-        """Test that initialize rejects empty hierarchy entries."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
-
-        with (
-            patch("agent_manager.config.config.message"),
-            patch(
-                "builtins.input",
-                side_effect=["org, , team", "org, team", "url1", "url2"],
-            ),
-            patch("agent_manager.config.config.Config.detect_repo_types", return_value=["git"]),
-            patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
-        ):
-            config.initialize()
-
-        # Should have retried and accepted the valid input
-        data = config.read()
-        assert len(data["hierarchy"]) == 2
+    def test_get_defaults_no_file(self, tmp_path):
+        config = Config(config_dir=tmp_path / "x")
+        defaults = config.get_defaults()
+        assert defaults == {"default_hierarchy": [], "default_agents": []}
 
 
-class TestConfigNormalizeUrl:
-    """Test cases for normalize_url static method."""
+# ===========================================================================
+# generate_template
+# ===========================================================================
+class TestGenerateTemplate:
 
-    def test_normalizes_relative_file_url(self, tmp_path):
-        """Test that relative file:// URLs are resolved to absolute paths."""
-        # Create a test directory
-        test_dir = tmp_path / "test_repo"
-        test_dir.mkdir()
+    def test_template_is_valid_yaml(self):
+        template = Config.generate_template()
+        parsed = yaml.safe_load(template)
+        assert "repos" in parsed
+        assert "default_hierarchy" in parsed
+        assert "directories" in parsed
 
-        # Change to tmp_path directory
-        import os
 
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(tmp_path)
-
-            # Test with relative path
-            url = "file://./test_repo"
-            normalized = Config.normalize_url(url)
-
-            # Should be absolute
-            assert normalized.startswith("file://")
-            assert str(test_dir) in normalized
-            assert "./" not in normalized
-        finally:
-            os.chdir(original_cwd)
-
-    def test_normalizes_relative_file_url_with_parent_dir(self, tmp_path):
-        """Test that relative file:// URLs with parent directory are resolved."""
-        # Create nested structure
-        parent = tmp_path / "parent"
-        parent.mkdir()
-        child = parent / "child"
-        child.mkdir()
-        target = tmp_path / "target"
-        target.mkdir()
-
-        import os
-
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(child)
-
-            # Test with parent directory reference
-            url = "file://../../target"
-            normalized = Config.normalize_url(url)
-
-            # Should be absolute
-            assert normalized.startswith("file://")
-            assert str(target) in normalized
-            assert ".." not in normalized
-        finally:
-            os.chdir(original_cwd)
-
-    def test_normalizes_tilde_in_file_url(self):
-        """Test that tilde (~) in file:// URLs is expanded."""
-        url = "file://~/repos/org"
-        normalized = Config.normalize_url(url)
-
-        # Should expand ~
-        assert "~" not in normalized
-        assert normalized.startswith("file://")
-        assert str(Path.home()) in normalized
-
-    def test_absolute_file_url_remains_unchanged(self, tmp_path):
-        """Test that absolute file:// URLs remain absolute."""
-        test_dir = tmp_path / "test_repo"
-        test_dir.mkdir()
-
-        url = f"file://{test_dir}"
-        normalized = Config.normalize_url(url)
-
-        # Should still be absolute and unchanged (except for potential path normalization)
-        assert normalized.startswith("file://")
-        assert str(test_dir) in normalized
+# ===========================================================================
+# URL utilities (unchanged from V1)
+# ===========================================================================
+class TestNormalizeUrl:
 
     def test_git_url_unchanged(self):
-        """Test that git URLs are not modified."""
         url = "https://github.com/user/repo.git"
-        normalized = Config.normalize_url(url)
+        assert Config.normalize_url(url) == url
 
-        # Should be unchanged
-        assert normalized == url
-
-    def test_ssh_git_url_unchanged(self):
-        """Test that SSH git URLs are not modified."""
+    def test_ssh_url_unchanged(self):
         url = "git@github.com:user/repo.git"
+        assert Config.normalize_url(url) == url
+
+    def test_tilde_expanded(self):
+        url = "file://~/repos/org"
         normalized = Config.normalize_url(url)
-
-        # Should be unchanged
-        assert normalized == url
-
-    def test_other_protocols_unchanged(self):
-        """Test that other protocol URLs are not modified."""
-        url = "s3://bucket/path/to/repo"
-        normalized = Config.normalize_url(url)
-
-        # Should be unchanged
-        assert normalized == url
+        assert "~" not in normalized
+        assert str(Path.home()) in normalized
 
 
-class TestConfigFileUrlResolution:
-    """Integration tests for file:// URL resolution in config operations."""
+class TestDetectRepoTypes:
 
-    def test_initialize_resolves_relative_file_urls(self, tmp_path):
-        """Test that initialize resolves relative file:// URLs to absolute paths."""
-        config_dir = tmp_path / "config"
-        repos_dir = tmp_path / "repos"
-        repos_dir.mkdir()
+    @patch("agent_manager.config.config.discover_repo_types")
+    def test_single_match(self, mock_discover):
+        mock_repo = Mock()
+        mock_repo.REPO_TYPE = "git"
+        mock_repo.can_handle_url.return_value = True
+        mock_discover.return_value = [mock_repo]
+        assert Config.detect_repo_types("https://github.com/x") == ["git"]
 
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
-
-        import os
-
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(tmp_path)
-
-            with (
-                patch("agent_manager.config.config.message"),
-                patch("builtins.input", side_effect=['["org"]', "file://./repos"]),
-                patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
-                patch(
-                    "agent_manager.config.config.Config.detect_repo_types",
-                    return_value=["file"],
-                ),
-            ):
-                config.initialize()
-
-            # Read back the config
-            with open(config.config_file) as f:
-                written_config = yaml.safe_load(f)
-
-            # URL should be absolute
-            url = written_config["hierarchy"][0]["url"]
-            assert url.startswith("file://")
-            assert "./" not in url
-            assert str(repos_dir) in url
-        finally:
-            os.chdir(original_cwd)
-
-    def test_add_level_resolves_relative_file_urls(self, tmp_path):
-        """Test that add_level resolves relative file:// URLs to absolute paths."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
-
-        # Create initial config with git URL
-        initial_config = {"hierarchy": [{"name": "org", "url": "https://github.com/org/repo", "repo_type": "git"}]}
-        with open(config.config_file, "w") as f:
-            yaml.dump(initial_config, f)
-
-        # Create a local repo directory
-        local_repo = tmp_path / "local"
-        local_repo.mkdir()
-
-        import os
-
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(tmp_path)
-
-            with (
-                patch("agent_manager.config.config.message"),
-                patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
-                patch(
-                    "agent_manager.config.config.Config.detect_repo_types",
-                    return_value=["file"],
-                ),
-                patch("agent_manager.config.config.create_repo"),
-            ):
-                config.add_level("personal", "file://./local")
-
-            # Read back the config
-            with open(config.config_file) as f:
-                written_config = yaml.safe_load(f)
-
-            # New URL should be absolute
-            personal_entry = [e for e in written_config["hierarchy"] if e["name"] == "personal"][0]
-            url = personal_entry["url"]
-            assert url.startswith("file://")
-            assert "./" not in url
-            assert str(local_repo) in url
-        finally:
-            os.chdir(original_cwd)
-
-    def test_update_level_resolves_relative_file_urls(self, tmp_path):
-        """Test that update_level resolves relative file:// URLs to absolute paths."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
-
-        # Create initial config
-        initial_config = {"hierarchy": [{"name": "org", "url": "https://github.com/org/repo", "repo_type": "git"}]}
-        with open(config.config_file, "w") as f:
-            yaml.dump(initial_config, f)
-
-        # Create a new local repo directory
-        new_local = tmp_path / "new_local"
-        new_local.mkdir()
-
-        import os
-
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(tmp_path)
-
-            with (
-                patch("agent_manager.config.config.message"),
-                patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
-                patch(
-                    "agent_manager.config.config.Config.detect_repo_types",
-                    return_value=["file"],
-                ),
-                patch("agent_manager.config.config.create_repo"),
-            ):
-                config.update_level("org", new_url="file://./new_local")
-
-            # Read back the config
-            with open(config.config_file) as f:
-                written_config = yaml.safe_load(f)
-
-            # Updated URL should be absolute
-            url = written_config["hierarchy"][0]["url"]
-            assert url.startswith("file://")
-            assert "./" not in url
-            assert str(new_local) in url
-        finally:
-            os.chdir(original_cwd)
+    @patch("agent_manager.config.config.discover_repo_types")
+    def test_no_match(self, mock_discover):
+        mock_repo = Mock()
+        mock_repo.can_handle_url.return_value = False
+        mock_discover.return_value = [mock_repo]
+        assert Config.detect_repo_types("bad://x") == []
 
 
-class TestConfigEdgeCases:
-    """Test cases for edge cases and special scenarios."""
+class TestPromptForRepoType:
 
-    def test_config_with_unicode_paths(self, tmp_path):
-        """Test Config with Unicode characters in paths."""
-        config_dir = tmp_path / "配置"
-        config = Config(config_dir=config_dir)
-
+    @patch("builtins.input", return_value="1")
+    def test_returns_selection(self, _mock_input):
         with patch("agent_manager.config.config.message"):
-            config.ensure_directories()
+            selected = Config.prompt_for_repo_type("url", ["git", "file"])
+        assert selected == "git"
 
-        assert config_dir.exists()
-
-    def test_validates_config_with_additional_fields(self):
-        """Test that validation allows additional fields."""
-        config = {
-            "hierarchy": [
-                {
-                    "name": "org",
-                    "url": "https://github.com/org/repo",
-                    "repo_type": "git",
-                    "extra_field": "extra_value",
-                }
-            ],
-            "mergers": {"JsonMerger": {"indent": 2}},
-        }
-
-        # Should not raise exception
-        Config.validate(config)
+    @patch("builtins.input", side_effect=["bad", "0", "2"])
+    def test_retries_on_bad_input(self, mock_input):
+        with patch("agent_manager.config.config.message"):
+            selected = Config.prompt_for_repo_type("url", ["a", "b"])
+        assert selected == "b"
+        assert mock_input.call_count == 3

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -137,9 +137,9 @@ class TestConfigCommand:
                         args = mock_process.call_args[0][0]
                         assert args.config_command == "show"
 
-    def test_config_add_command(self):
-        """Test config add command with parameters."""
-        with patch("sys.argv", ["agent-manager", "config", "add", "test-level", "https://github.com/test/repo"]):
+    def test_config_defaults_command(self):
+        """Test config defaults command with parameters."""
+        with patch("sys.argv", ["agent-manager", "config", "defaults", "--repos", "org", "personal"]):
             with patch("agent_manager.agent_manager.Config") as mock_config:
                 with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command") as mock_process:
                     with patch("agent_manager.agent_manager.get_output"):
@@ -149,9 +149,8 @@ class TestConfigCommand:
 
                         assert mock_process.called
                         args = mock_process.call_args[0][0]
-                        assert args.config_command == "add"
-                        assert args.name == "test-level"
-                        assert args.url == "https://github.com/test/repo"
+                        assert args.config_command == "defaults"
+                        assert args.repos == ["org", "personal"]
 
     def test_config_command_early_return(self):
         """Test that config command returns early without initializing repos."""
@@ -514,7 +513,7 @@ class TestIntegration:
 
     def test_config_command_workflow(self):
         """Test complete config management workflow."""
-        with patch("sys.argv", ["agent-manager", "-v", "config", "add", "team", "https://github.com/test/team"]):
+        with patch("sys.argv", ["agent-manager", "-v", "config", "show"]):
             with patch("agent_manager.agent_manager.Config") as mock_config:
                 with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command") as mock_process:
                     with patch("agent_manager.agent_manager.get_output") as mock_output:


### PR DESCRIPTION
## Summary

- Replace flat `hierarchy` list with V2 config schema: `repos`, `default_hierarchy`, `default_agents`, `directories`
- Rewrite `Config` class with new validation, read/write, and CRUD methods for repos, directories, and defaults
- Replace old CLI commands (add/remove/update/move/export/import) with V2 commands (show, validate, template, defaults, where, init, edit)
- Comprehensive test coverage: 102 config tests + 2 integration tests rewritten for V2 schema

## V2 Config Schema

```yaml
repos:
  - name: org
    url: https://github.com/org/ai-configs.git
    repo_type: git
  - name: personal
    url: file:///home/user/personal_ai
    repo_type: file

default_hierarchy:
  - org
  - personal

default_agents:
  - cursor
  - claude

directories:
  HOME:
    type: local
  HOME/GIT/my-project:
    type: git
    agents: [cursor]
    hierarchy: [personal]
```

## Test plan

- [x] All 102 config tests pass
- [x] Integration tests updated and passing
- [x] ruff lint clean
- [ ] Manual smoke test of `config show`, `config template`, `config defaults`


Made with [Cursor](https://cursor.com)