### PR TITLE
PR 3: Repo safety methods (detect_directory, safe_to_overwrite)

### DIFF
--- a/agent_manager/cli_extensions/agent_commands.py
+++ b/agent_manager/cli_extensions/agent_commands.py
@@ -18,41 +18,45 @@ class AgentCommands:
         Args:
             subparsers: The argparse subparsers to add to
         """
-        # Discover available plugins for the choices
         agent_plugin_names = get_agent_names()
 
         # Agents command group
-        agents_parser = subparsers.add_parser("agents", help="Manage agent plugins")
-        agents_subparsers = agents_parser.add_subparsers(dest="agents_command", help="Agent commands")
+        agents_parser = subparsers.add_parser(
+            "agents", help="Manage agent plugins",
+        )
+        agents_subparsers = agents_parser.add_subparsers(
+            dest="agents_command", help="Agent commands",
+        )
 
-        # agents list
         agents_subparsers.add_parser(
             "list",
             help="List available agent plugins",
-            description="Show all discovered agent plugins, including their package names and enabled/disabled status.",
+            description=(
+                "Show all discovered agent plugins, including their "
+                "package names and enabled/disabled status."
+            ),
         )
 
-        # agents enable
         enable_parser = agents_subparsers.add_parser(
             "enable",
             help="Enable an agent plugin",
-            description="Re-enable a previously disabled agent plugin so it will be included when running 'agent-manager run'.",
         )
         enable_parser.add_argument("name", help="Agent name (e.g., claude)")
 
-        # agents disable
         disable_parser = agents_subparsers.add_parser(
             "disable",
             help="Disable an agent plugin",
-            description="Disable an agent plugin so it will be skipped when running 'agent-manager run'. The plugin remains installed but inactive.",
         )
         disable_parser.add_argument("name", help="Agent name (e.g., claude)")
 
-        # Run command (default action)
+        # Run command
         run_parser = subparsers.add_parser(
             "run",
-            help="Run an agent (default command)",
-            description="Merge configurations from the hierarchy and apply them to the specified agent(s). This updates repositories, merges files using type-aware strategies, and writes the result to each agent's configuration directory.",
+            help="Run agent(s) for configured directories",
+            description=(
+                "Merge configurations from repos and apply them to "
+                "the specified agent(s) in configured directories."
+            ),
         )
         run_parser.add_argument(
             "--agent",
@@ -61,27 +65,42 @@ class AgentCommands:
             choices=["all"] + agent_plugin_names,
             help="Agent plugin to use (default: all agents)",
         )
-        run_parser.add_argument(
-            "--scope",
-            type=str,
-            default="default",
-            help="Configuration scope to use (default: 'default'). Available scopes depend on the agent.",
-        )
 
     @classmethod
-    def process_agents_command(cls, args: argparse.Namespace) -> None:
-        """Process agents-related CLI commands.
-
-        Args:
-            args: Parsed command-line arguments
-        """
-        if not hasattr(args, "agents_command") or args.agents_command is None:
-            message("Usage: agent-manager agents <command>", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+    def process_agents_command(
+        cls, args: argparse.Namespace,
+    ) -> None:
+        """Process agents-related CLI commands."""
+        if (
+            not hasattr(args, "agents_command")
+            or args.agents_command is None
+        ):
+            message(
+                "Usage: agent-manager agents <command>",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
             message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("Available commands:", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("  list      List available agent plugins", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("  enable    Enable an agent plugin", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("  disable   Disable an agent plugin", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message(
+                "Available commands:",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+            message(
+                "  list      List available agent plugins",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+            message(
+                "  enable    Enable an agent plugin",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+            message(
+                "  disable   Disable an agent plugin",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
             return
 
         if args.agents_command == "list":
@@ -94,62 +113,87 @@ class AgentCommands:
     @classmethod
     def list_agents(cls) -> None:
         """List all available agent plugins."""
-        message("\n=== Available Agent Plugins ===\n", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        message(
+            "\n=== Available Agent Plugins ===\n",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
 
-        # Get disabled agents
         disabled = get_disabled_plugins().get("agents", [])
-
         plugins = discover_agent_plugins()
 
         if not plugins and not disabled:
-            message("No agent plugins found.", MessageType.NORMAL, VerbosityLevel.ALWAYS)
             message(
-                "\nTo install an agent plugin, use: pip install <plugin-package>",
+                "No agent plugins found.",
                 MessageType.NORMAL,
                 VerbosityLevel.ALWAYS,
             )
             message(
-                "Agent plugins have package names starting with 'am_agent_'", MessageType.NORMAL, VerbosityLevel.ALWAYS
+                "\nTo install an agent plugin, use: "
+                "pip install <plugin-package>",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+            message(
+                "Agent plugins have package names starting "
+                "with 'am_agent_'",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
             )
             message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
             return
 
         if plugins:
-            message("Installed agents:", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message(
+                "Installed agents:",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
             for agent_name in sorted(plugins.keys()):
                 package_name = plugins[agent_name]["package_name"]
-                message(f"  {agent_name} ({package_name})", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+                message(
+                    f"  {agent_name} ({package_name})",
+                    MessageType.NORMAL,
+                    VerbosityLevel.ALWAYS,
+                )
             message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
 
-        # Show disabled agents
         if disabled:
-            message("Disabled agents:", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message(
+                "Disabled agents:",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
             for name in disabled:
-                message(f"  {name} (disabled)", MessageType.WARNING, VerbosityLevel.ALWAYS)
+                message(
+                    f"  {name} (disabled)",
+                    MessageType.WARNING,
+                    VerbosityLevel.ALWAYS,
+                )
             message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("Use 'agent-manager agents enable <name>' to re-enable", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message(
+                "Use 'agent-manager agents enable <name>' to re-enable",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
             message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
 
-        message(f"Total: {len(plugins)} enabled, {len(disabled)} disabled", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        message(
+            f"Total: {len(plugins)} enabled, {len(disabled)} disabled",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
         message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
 
     @classmethod
     def enable_agent(cls, name: str) -> None:
-        """Enable an agent plugin.
-
-        Args:
-            name: Name of the agent to enable
-        """
+        """Enable an agent plugin."""
         if not set_plugin_enabled("agents", name, enabled=True):
             sys.exit(1)
 
     @classmethod
     def disable_agent(cls, name: str) -> None:
-        """Disable an agent plugin.
-
-        Args:
-            name: Name of the agent to disable
-        """
+        """Disable an agent plugin."""
         if not set_plugin_enabled("agents", name, enabled=False):
             sys.exit(1)
 
@@ -157,15 +201,33 @@ class AgentCommands:
     def process_cli_command(cls, args, config_data: dict) -> None:
         """Process the run command for agents.
 
+        This is a transitional implementation. The full directory-iteration
+        loop will be implemented in PR 7 (main loop rewrite).
+
         Args:
             args: Parsed command-line arguments
-            config_data: Configuration data with repo objects
+            config_data: V2 configuration data with repos, directories, etc.
         """
-        # Determine which agents to run
-        agents_to_run = [args.agent] if args.agent != "all" else ["all"]
+        agents_to_run = (
+            [args.agent] if args.agent != "all" else ["all"]
+        )
 
-        # Get scope from args (defaults to "default")
-        scope = getattr(args, "scope", "default")
+        # TODO(PR 7): iterate config_data["directories"], resolve
+        # hierarchy per directory, and call run_agents for each.
+        # For now, just pass the repos list directly.
+        message(
+            "Warning: full directory-based run loop not yet implemented "
+            "(PR 7). Running agents against all repos.",
+            MessageType.WARNING,
+            VerbosityLevel.VERBOSE,
+        )
 
-        # Use the core module to run agents
-        run_agents(agents_to_run, config_data, scope=scope)
+        from pathlib import Path
+
+        repos = config_data.get("repos", [])
+        merger_settings = config_data.get("mergers", {})
+        base_directory = Path.home()
+
+        run_agents(
+            agents_to_run, repos, base_directory, merger_settings,
+        )

--- a/agent_manager/cli_extensions/config_commands.py
+++ b/agent_manager/cli_extensions/config_commands.py
@@ -1,12 +1,9 @@
-"""CLI commands for managing configuration."""
+"""CLI commands for managing configuration (V2 schema)."""
 
 import argparse
 import sys
 
-import yaml
-
 from agent_manager.config import Config
-from agent_manager.core import create_repo
 from agent_manager.output import MessageType, VerbosityLevel, message
 
 
@@ -20,93 +17,65 @@ class ConfigCommands:
         Args:
             subparsers: The subparsers object to add commands to
         """
-        # Config command group
         config_parser = subparsers.add_parser("config", help="Manage configuration")
         config_subparsers = config_parser.add_subparsers(dest="config_command", help="Configuration commands")
 
-        # config init
-        config_subparsers.add_parser(
-            "init",
-            help="Initialize or reinitialize configuration",
-            description="Create a new configuration file at ~/.agent-manager/config.yaml through an interactive setup wizard. If a configuration already exists, it will be re-initialized.",
-        )
-
         # config show
-        show_parser = config_subparsers.add_parser(
+        config_subparsers.add_parser(
             "show",
-            help="Display current hierarchy",
-            description="Display the current configuration hierarchy, showing each level's name, repository type, and URL in priority order (lowest to highest).",
+            help="Display current configuration",
+            description="Display the current configuration including repos, defaults, and directories.",
         )
-        show_parser.add_argument("--resolve-paths", action="store_true", help="Resolve file:// URLs to absolute paths")
-
-        # config add
-        add_parser = config_subparsers.add_parser(
-            "add",
-            help="Add a new hierarchy level",
-            description="Add a new hierarchy level with a name and repository URL. The level is appended to the end (highest priority) unless --position is specified.",
-        )
-        add_parser.add_argument("name", help="Name of the hierarchy level")
-        add_parser.add_argument("url", help="Repository URL (git URL or file:// path)")
-        add_parser.add_argument("--position", type=int, help="Position to insert (0-based, default: append to end)")
-
-        # config remove
-        remove_parser = config_subparsers.add_parser(
-            "remove",
-            help="Remove a hierarchy level",
-            description="Remove a hierarchy level by name from the configuration. This does not delete any cached repository data on disk.",
-        )
-        remove_parser.add_argument("name", help="Name of the hierarchy level to remove")
-
-        # config update
-        update_parser = config_subparsers.add_parser(
-            "update",
-            help="Update an existing hierarchy level",
-            description="Change the URL or name of an existing hierarchy level. At least one of --url or --rename must be provided.",
-        )
-        update_parser.add_argument("name", help="Name of the hierarchy level to update")
-        update_parser.add_argument("--url", help="New repository URL (git URL or file:// path)")
-        update_parser.add_argument("--rename", help="New name for the hierarchy level")
-
-        # config move
-        move_parser = config_subparsers.add_parser(
-            "move",
-            help="Move a hierarchy level to a new position",
-            description="Change the position of a hierarchy level within the priority order. Levels later in the list have higher priority and their values take precedence during merging.",
-        )
-        move_parser.add_argument("name", help="Name of the hierarchy level to move")
-        move_group = move_parser.add_mutually_exclusive_group(required=True)
-        move_group.add_argument("--position", type=int, help="New position (0-based)")
-        move_group.add_argument("--up", action="store_true", help="Move up one position")
-        move_group.add_argument("--down", action="store_true", help="Move down one position")
 
         # config validate
         config_subparsers.add_parser(
             "validate",
-            help="Validate all repository URLs",
-            description="Check that all repository URLs in the hierarchy are valid and accessible. Reports which repositories pass or fail validation.",
+            help="Validate configuration",
+            description="Validate the configuration file structure and check that all repository URLs are accessible.",
         )
 
-        # config export
-        export_parser = config_subparsers.add_parser(
-            "export",
-            help="Export configuration to a file or stdout",
-            description="Export the current configuration as YAML to a file or to stdout. Useful for backing up or sharing configurations.",
+        # config template
+        config_subparsers.add_parser(
+            "template",
+            help="Dump a starter configuration template to stdout",
+            description="Print a commented YAML template to stdout that can be redirected to a config file.",
         )
-        export_parser.add_argument("file", nargs="?", help="Output file (default: stdout)")
 
-        # config import
-        import_parser = config_subparsers.add_parser(
-            "import",
-            help="Import configuration from a file",
-            description="Import a configuration from a YAML file, replacing the current configuration. You will be prompted before overwriting an existing configuration.",
+        # config defaults
+        defaults_parser = config_subparsers.add_parser(
+            "defaults",
+            help="Show or set default hierarchy and agents",
+            description="Show or set the default_hierarchy and default_agents. "
+            "When called with flags, the lists are replaced entirely (declarative).",
         )
-        import_parser.add_argument("file", help="Input file to import")
+        defaults_parser.add_argument(
+            "--repos", nargs="+", metavar="NAME",
+            help="Set default_hierarchy (declarative, full replace)",
+        )
+        defaults_parser.add_argument(
+            "--agents", nargs="+", metavar="NAME",
+            help="Set default_agents (declarative, full replace)",
+        )
 
         # config where
         config_subparsers.add_parser(
             "where",
             help="Show configuration file location",
-            description="Show the file paths for the configuration file, config directory, and repos directory, along with whether each exists on disk.",
+            description="Show the file paths for the configuration file, config directory, and repos directory.",
+        )
+
+        # config init (placeholder for future wizard, currently creates from template)
+        config_subparsers.add_parser(
+            "init",
+            help="Initialize configuration (interactive wizard)",
+            description="Create a new configuration file through an interactive setup wizard.",
+        )
+
+        # config edit (placeholder for future editor integration)
+        config_subparsers.add_parser(
+            "edit",
+            help="Edit configuration in $EDITOR",
+            description="Open the configuration file in your default editor, validate on save.",
         )
 
     @staticmethod
@@ -118,214 +87,179 @@ class ConfigCommands:
             config: Config instance to operate on
         """
         if args.config_command is None:
-            # No subcommand provided, show available commands
             message("Usage: agent-manager config <command>", MessageType.NORMAL, VerbosityLevel.ALWAYS)
             message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
             message("Available commands:", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("  init      Initialize or reinitialize configuration", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("  show      Display current hierarchy", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("  add       Add a new hierarchy level", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("  remove    Remove a hierarchy level", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("  update    Update an existing hierarchy level", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("  move      Move a hierarchy level to a new position", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("  validate  Validate all repository URLs", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("  export    Export configuration to a file or stdout", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("  import    Import configuration from a file", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-            message("  where     Show configuration file location", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("  show       Display current configuration", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("  validate   Validate configuration", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("  template   Dump starter template to stdout", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("  defaults   Show or set default hierarchy/agents", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("  where      Show configuration file location", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("  init       Initialize configuration (wizard)", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("  edit       Edit configuration in $EDITOR", MessageType.NORMAL, VerbosityLevel.ALWAYS)
             return
-        elif args.config_command == "init":
-            config.initialize(skip_if_already_created=False)
         elif args.config_command == "show":
-            resolve = getattr(args, "resolve_paths", False)
-            ConfigCommands.display(config, resolve_paths=resolve)
-        elif args.config_command == "add":
-            config.add_level(args.name, args.url, args.position)
-        elif args.config_command == "remove":
-            config.remove_level(args.name)
-        elif args.config_command == "update":
-            config.update_level(args.name, args.url, args.rename)
-        elif args.config_command == "move":
-            direction = None
-            if getattr(args, "up", False):
-                direction = "up"
-            elif getattr(args, "down", False):
-                direction = "down"
-            config.move_level(args.name, args.position, direction)
+            ConfigCommands.display(config)
         elif args.config_command == "validate":
             ConfigCommands.validate_all(config)
-        elif args.config_command == "export":
-            output_file = getattr(args, "file", None)
-            ConfigCommands.export_config(config, output_file)
-        elif args.config_command == "import":
-            ConfigCommands.import_config(config, args.file)
+        elif args.config_command == "template":
+            ConfigCommands.template()
+        elif args.config_command == "defaults":
+            repos = getattr(args, "repos", None)
+            agents = getattr(args, "agents", None)
+            ConfigCommands.defaults(config, repos, agents)
         elif args.config_command == "where":
             ConfigCommands.show_location(config)
+        elif args.config_command == "init":
+            message("Interactive wizard not yet implemented. Use 'config template' to generate a starter config.",
+                    MessageType.WARNING, VerbosityLevel.ALWAYS)
+        elif args.config_command == "edit":
+            message("Editor integration not yet implemented. Use 'config where' to find the file path.",
+                    MessageType.WARNING, VerbosityLevel.ALWAYS)
         else:
-            # This shouldn't happen if argparse is set up correctly
             message("Unknown config command", MessageType.ERROR, VerbosityLevel.ALWAYS)
             sys.exit(1)
 
     @staticmethod
-    def display(config: Config, resolve_paths: bool = False) -> None:
-        """Display the current hierarchy configuration.
+    def display(config: Config) -> None:
+        """Display the current configuration.
 
         Args:
             config: Config instance
-            resolve_paths: If True, show resolved paths for repositories
         """
         if not config.exists():
-            message(
-                "No configuration file found. Run without arguments to create one.",
-                MessageType.ERROR,
-                VerbosityLevel.ALWAYS,
-            )
+            message("No configuration file found. Run 'agent-manager config init' to create one.",
+                    MessageType.ERROR, VerbosityLevel.ALWAYS)
             sys.exit(1)
 
         config_data = config.read()
-        message("\nCurrent Hierarchy (lowest to highest priority):\n", MessageType.NORMAL, VerbosityLevel.ALWAYS)
 
-        for idx, entry in enumerate(config_data["hierarchy"], 1):
-            priority = "→" * idx
-            message(f"  {priority} {entry['name']}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        # Repos
+        repos = config_data.get("repos", [])
+        message("\n=== Repos ===\n", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        if repos:
+            for entry in repos:
+                message(f"  {entry['name']} ({entry.get('repo_type', 'unknown')})",
+                        MessageType.NORMAL, VerbosityLevel.ALWAYS)
+                message(f"    URL: {entry['url']}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        else:
+            message("  (none)", MessageType.NORMAL, VerbosityLevel.ALWAYS)
 
-            message(f"      Type: {entry.get('repo_type', 'unknown')}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        # Default hierarchy
+        default_hierarchy = config_data.get("default_hierarchy", [])
+        message("\n=== Default Hierarchy ===\n", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        if default_hierarchy:
+            for idx, name in enumerate(default_hierarchy, 1):
+                message(f"  {idx}. {name}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        else:
+            message("  (not set)", MessageType.NORMAL, VerbosityLevel.ALWAYS)
 
-            url = entry["url"]
-            message(f"      URL: {url}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        # Default agents
+        default_agents = config_data.get("default_agents", [])
+        message("\n=== Default Agents ===\n", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        if default_agents:
+            for name in default_agents:
+                message(f"  - {name}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        else:
+            message("  (not set -- falls back to all enabled agents)", MessageType.NORMAL, VerbosityLevel.ALWAYS)
 
-            # Use pluggable repo architecture for resolved display
-            if resolve_paths:
-                try:
-                    # Create temporary repo instance for display
-                    repo = create_repo(entry["name"], entry["url"], config.repos_directory, entry["repo_type"])
-                    resolved = repo.get_display_url()
-                    # Only show if different from original URL
-                    if resolved != url:
-                        message(f"      Resolved: {resolved}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-                except Exception as e:
-                    message(f"Failed to resolve path for {entry['name']}: {e}", MessageType.DEBUG, VerbosityLevel.DEBUG)
+        # Directories
+        directories = config_data.get("directories", {})
+        message("\n=== Directories ===\n", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        if directories:
+            for dir_path, dir_config in directories.items():
+                if dir_config is None:
+                    dir_config = {}
+                dir_type = dir_config.get("type", "unset")
+                agents = dir_config.get("agents")
+                hierarchy = dir_config.get("hierarchy")
 
-            message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+                message(f"  {dir_path}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+                message(f"    type: {dir_type}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+                if agents:
+                    message(f"    agents: {', '.join(agents)}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+                else:
+                    message("    agents: (inherits default)", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+                if hierarchy:
+                    message(f"    hierarchy: {' -> '.join(hierarchy)}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+                else:
+                    message("    hierarchy: (inherits default)", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        else:
+            message("  (none)", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+
+        message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
 
     @staticmethod
     def validate_all(config: Config) -> None:
-        """Validate all repository URLs in the configuration.
+        """Validate configuration structure and repository URLs.
 
         Args:
             config: Config instance
         """
         if not config.exists():
-            message(
-                "No configuration file found. Run without arguments to create one.",
-                MessageType.ERROR,
-                VerbosityLevel.ALWAYS,
-            )
+            message("No configuration file found. Run 'agent-manager config init' to create one.",
+                    MessageType.ERROR, VerbosityLevel.ALWAYS)
             sys.exit(1)
 
+        # First validate structure (read does this)
         config_data = config.read()
-        message("\nValidating all repositories...\n", MessageType.INFO, VerbosityLevel.EXTRA_VERBOSE)
+
+        repos = config_data.get("repos", [])
+        message("\nValidating repository URLs...\n", MessageType.NORMAL, VerbosityLevel.ALWAYS)
 
         all_valid = True
-        for idx, entry in enumerate(config_data["hierarchy"]):
+        for idx, entry in enumerate(repos):
             name = entry["name"]
             url = entry["url"]
+            total = len(repos)
 
-            total = len(config_data["hierarchy"])
             message(f"[{idx + 1}/{total}] {name}: {url}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-
             if config.validate_repo_url(url):
-                message("  ✓ Valid", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
+                message("  Valid", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
             else:
-                message("  ✗ Invalid or inaccessible", MessageType.ERROR, VerbosityLevel.ALWAYS)
+                message("  Invalid or inaccessible", MessageType.ERROR, VerbosityLevel.ALWAYS)
                 all_valid = False
 
         message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
         if all_valid:
-            message("✓ All repositories are valid and accessible!", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
+            message("All repositories are valid and accessible!", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
         else:
-            message(
-                "Some repositories failed validation. Please check the errors above.",
-                MessageType.WARNING,
-                VerbosityLevel.ALWAYS,
-            )
+            message("Some repositories failed validation.", MessageType.WARNING, VerbosityLevel.ALWAYS)
             sys.exit(1)
 
     @staticmethod
-    def export_config(config: Config, output_file: str | None = None) -> None:
-        """Export configuration to a file or stdout.
-
-        Args:
-            config: Config instance
-            output_file: Optional output file path. If None, write to stdout.
-        """
-        if not config.exists():
-            message("No configuration file found. Nothing to export.", MessageType.ERROR, VerbosityLevel.ALWAYS)
-            sys.exit(1)
-
-        config_data = config.read()
-
-        # Remove repo objects before exporting (they're not serializable)
-        export_data = {"hierarchy": []}
-        for entry in config_data["hierarchy"]:
-            export_entry = {"name": entry["name"], "url": entry["url"], "repo_type": entry["repo_type"]}
-            export_data["hierarchy"].append(export_entry)
-
-        # Include mergers section if present
-        if "mergers" in config_data:
-            export_data["mergers"] = config_data["mergers"]
-
-        if output_file:
-            try:
-                with open(output_file, "w") as f:
-                    yaml.dump(export_data, f, default_flow_style=False, sort_keys=False)
-                message(f"Configuration exported to {output_file}", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
-            except Exception as e:
-                message(f"Failed to export configuration: {e}", MessageType.ERROR, VerbosityLevel.ALWAYS)
-                sys.exit(1)
-        else:
-            # Write to stdout
-            print(yaml.dump(export_data, default_flow_style=False, sort_keys=False))
+    def template() -> None:
+        """Dump a starter configuration template to stdout."""
+        print(Config.generate_template())
 
     @staticmethod
-    def import_config(config: Config, input_file: str) -> None:
-        """Import configuration from a file.
+    def defaults(config: Config, repos: list[str] | None = None, agents: list[str] | None = None) -> None:
+        """Show or set default_hierarchy and default_agents.
 
         Args:
             config: Config instance
-            input_file: Input file path to import from
+            repos: If provided, set default_hierarchy (full replace)
+            agents: If provided, set default_agents (full replace)
         """
-        try:
-            with open(input_file) as f:
-                imported_data = yaml.safe_load(f)
-        except FileNotFoundError:
-            message(f"File not found: {input_file}", MessageType.ERROR, VerbosityLevel.ALWAYS)
-            sys.exit(1)
-        except yaml.YAMLError as e:
-            message(f"Invalid YAML file: {e}", MessageType.ERROR, VerbosityLevel.ALWAYS)
-            sys.exit(1)
-        except Exception as e:
-            message(f"Failed to read file: {e}", MessageType.ERROR, VerbosityLevel.ALWAYS)
-            sys.exit(1)
+        if repos is None and agents is None:
+            # Show current defaults
+            defaults = config.get_defaults()
+            message("\nDefault hierarchy:", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            if defaults["default_hierarchy"]:
+                for idx, name in enumerate(defaults["default_hierarchy"], 1):
+                    message(f"  {idx}. {name}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            else:
+                message("  (not set)", MessageType.NORMAL, VerbosityLevel.ALWAYS)
 
-        # Validate imported data
-        if not isinstance(imported_data, dict) or "hierarchy" not in imported_data:
-            message("Invalid configuration file: missing 'hierarchy' key", MessageType.ERROR, VerbosityLevel.ALWAYS)
-            sys.exit(1)
-
-        # Warn if overwriting existing config
-        if config.exists():
-            response = input(f"Configuration file already exists at {config.config_file}. Overwrite? (yes/no): ")
-            if response.lower() not in ["yes", "y"]:
-                message("Import cancelled.", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-                return
-
-        # Write imported config
-        try:
-            config.write(imported_data)
-            message(f"✓ Configuration imported from {input_file}", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
-        except Exception as e:
-            message(f"Failed to import configuration: {e}", MessageType.ERROR, VerbosityLevel.ALWAYS)
-            sys.exit(1)
+            message("\nDefault agents:", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            if defaults["default_agents"]:
+                for name in defaults["default_agents"]:
+                    message(f"  - {name}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            else:
+                message("  (not set -- falls back to all enabled agents)", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+            message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        else:
+            config.set_defaults(repos=repos, agents=agents)
 
     @staticmethod
     def show_location(config: Config) -> None:
@@ -340,21 +274,20 @@ class ConfigCommands:
         message(f"  Config file:      {config.config_file}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
         message(f"  Repos directory:  {config.repos_directory}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
 
-        # Show status
         message("\nStatus:", MessageType.NORMAL, VerbosityLevel.ALWAYS)
         if config.config_file.exists():
-            message("  ✓ Configuration file exists", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
+            message("  Config file exists", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
         else:
-            message("  ✗ Configuration file does not exist", MessageType.WARNING, VerbosityLevel.ALWAYS)
+            message("  Config file does not exist", MessageType.WARNING, VerbosityLevel.ALWAYS)
 
         if config.config_directory.exists():
-            message("  ✓ Config directory exists", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
+            message("  Config directory exists", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
         else:
-            message("  ✗ Config directory does not exist", MessageType.WARNING, VerbosityLevel.ALWAYS)
+            message("  Config directory does not exist", MessageType.WARNING, VerbosityLevel.ALWAYS)
 
         if config.repos_directory.exists():
-            message("  ✓ Repos directory exists", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
+            message("  Repos directory exists", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
         else:
-            message("  ✗ Repos directory does not exist", MessageType.WARNING, VerbosityLevel.ALWAYS)
+            message("  Repos directory does not exist", MessageType.WARNING, VerbosityLevel.ALWAYS)
 
         message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)

--- a/agent_manager/config/__init__.py
+++ b/agent_manager/config/__init__.py
@@ -1,5 +1,5 @@
 """Configuration management for agent-manager."""
 
-from .config import Config, HierarchyEntry
+from .config import Config, ConfigData, ConfigError, DirectoryEntry, RepoEntry
 
-__all__ = ["Config", "HierarchyEntry"]
+__all__ = ["Config", "ConfigData", "ConfigError", "DirectoryEntry", "RepoEntry"]

--- a/agent_manager/core/agents.py
+++ b/agent_manager/core/agents.py
@@ -1,15 +1,23 @@
 """Agent discovery utilities for agent-manager."""
 
 import sys
+from pathlib import Path
+from typing import Any
 
 from agent_manager.output import MessageType, VerbosityLevel, message
-from agent_manager.utils import discover_external_plugins, filter_disabled_plugins, load_plugin_class
+from agent_manager.utils import (
+    discover_external_plugins,
+    filter_disabled_plugins,
+    load_plugin_class,
+)
 
 # Package prefix for agent plugins
 AGENT_PLUGIN_PREFIX = "am_agent_"
 
 
-def discover_agent_plugins(include_disabled: bool = False) -> dict[str, dict]:
+def discover_agent_plugins(
+    include_disabled: bool = False,
+) -> dict[str, dict]:
     """Discover all available agent plugins.
 
     Agent plugins are discovered by searching for installed packages
@@ -19,20 +27,13 @@ def discover_agent_plugins(include_disabled: bool = False) -> dict[str, dict]:
         include_disabled: If True, include disabled agent plugins
 
     Returns:
-        Dictionary mapping agent names to plugin info:
-        {
-            "claude": {
-                "package_name": "am_agent_claude",
-                "source": "package"
-            }
-        }
+        Dictionary mapping agent names to plugin info
     """
     plugins = discover_external_plugins(
         plugin_type="agent",
         package_prefix=AGENT_PLUGIN_PREFIX,
     )
 
-    # Filter out disabled plugins unless requested
     if not include_disabled:
         plugins = filter_disabled_plugins(plugins, "agents")
 
@@ -43,18 +44,20 @@ def get_agent_names() -> list[str]:
     """Get list of available agent plugin names.
 
     Returns:
-        List of agent names (e.g., ["claude", "copilot"])
+        List of agent names (e.g., ["claude", "cursor"])
     """
     plugins = discover_agent_plugins()
     return sorted(plugins.keys())
 
 
-def load_agent(agent_name: str, plugins: dict[str, dict] | None = None):
+def load_agent(
+    agent_name: str, plugins: dict[str, dict] | None = None
+):
     """Load an agent class by name.
 
     Args:
         agent_name: Name of the agent (e.g., "claude")
-        plugins: Optional pre-discovered plugins dict. If None, will discover.
+        plugins: Optional pre-discovered plugins dict.
 
     Returns:
         Instance of the Agent class
@@ -66,71 +69,91 @@ def load_agent(agent_name: str, plugins: dict[str, dict] | None = None):
         plugins = discover_agent_plugins()
 
     if agent_name not in plugins:
-        message(f"Agent '{agent_name}' not found", MessageType.ERROR, VerbosityLevel.ALWAYS)
-        available = ", ".join(sorted(plugins.keys())) if plugins else "none"
-        message(f"Available agents: {available}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-        sys.exit(1)
-
-    plugin_info = plugins[agent_name]
-    message(f"Loading agent plugin: {plugin_info['package_name']}", MessageType.DEBUG, VerbosityLevel.DEBUG)
-
-    try:
-        agent_class = load_plugin_class(plugin_info, "Agent")
-        return agent_class()
-    except Exception as e:
-        message(f"Failed to load agent '{agent_name}': {e}", MessageType.ERROR, VerbosityLevel.ALWAYS)
-        sys.exit(1)
-
-
-def run_agents(agent_names: list[str], config_data: dict, scope: str = "default") -> None:
-    """Run one or more agents with the given configuration.
-
-    Args:
-        agent_names: List of agent names to run, or ["all"] for all agents
-        config_data: Configuration data with repo objects
-        scope: Configuration scope to use (default: "default")
-    """
-    plugins = discover_agent_plugins()
-
-    # Determine which agents to run
-    agents_to_run = sorted(plugins.keys()) if agent_names == ["all"] or "all" in agent_names else agent_names
-
-    # Check if we have any agents
-    if not agents_to_run:
-        message("No agent plugins found", MessageType.ERROR, VerbosityLevel.ALWAYS)
         message(
-            "Please install an agent plugin (e.g., pip install -e am_agent_claude)",
+            f"Agent '{agent_name}' not found",
+            MessageType.ERROR,
+            VerbosityLevel.ALWAYS,
+        )
+        available = (
+            ", ".join(sorted(plugins.keys())) if plugins else "none"
+        )
+        message(
+            f"Available agents: {available}",
             MessageType.NORMAL,
             VerbosityLevel.ALWAYS,
         )
         sys.exit(1)
 
-    # Run each agent
+    plugin_info = plugins[agent_name]
+    message(
+        f"Loading agent plugin: {plugin_info['package_name']}",
+        MessageType.DEBUG,
+        VerbosityLevel.DEBUG,
+    )
+
+    try:
+        agent_class = load_plugin_class(plugin_info, "Agent")
+        return agent_class()
+    except Exception as e:
+        message(
+            f"Failed to load agent '{agent_name}': {e}",
+            MessageType.ERROR,
+            VerbosityLevel.ALWAYS,
+        )
+        sys.exit(1)
+
+
+def run_agents(
+    agent_names: list[str],
+    repos: list[dict[str, Any]],
+    base_directory: Path,
+    merger_settings: dict[str, Any] | None = None,
+) -> None:
+    """Run one or more agents with the given configuration.
+
+    Args:
+        agent_names: List of agent names to run, or ["all"] for all
+        repos: Ordered list of repo entries (lowest to highest priority)
+        base_directory: Resolved target directory
+        merger_settings: Optional per-merger settings from config
+    """
+    plugins = discover_agent_plugins()
+
+    agents_to_run = (
+        sorted(plugins.keys())
+        if agent_names == ["all"] or "all" in agent_names
+        else agent_names
+    )
+
+    if not agents_to_run:
+        message(
+            "No agent plugins found",
+            MessageType.ERROR,
+            VerbosityLevel.ALWAYS,
+        )
+        message(
+            "Install an agent plugin (e.g., pip install -e am_agent_claude)",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+        sys.exit(1)
+
     for agent_name in agents_to_run:
-        message(f"\nInitializing agent: {agent_name}", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        message(
+            f"\nInitializing agent: {agent_name}",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
 
         try:
             agent = load_agent(agent_name, plugins)
-
-            # Validate scope for this agent
-            available_scopes = agent.get_scope_names()
-            if scope not in available_scopes:
-                message(
-                    f"Scope '{scope}' not supported by agent '{agent_name}'",
-                    MessageType.ERROR,
-                    VerbosityLevel.ALWAYS,
-                )
-                message(
-                    f"Available scopes: {', '.join(available_scopes)}",
-                    MessageType.NORMAL,
-                    VerbosityLevel.ALWAYS,
-                )
-                sys.exit(1)
-
-            message(f"Using scope: {scope}", MessageType.INFO, VerbosityLevel.VERBOSE)
-            agent.update(config_data, scope=scope)
+            agent.update(repos, base_directory, merger_settings)
         except SystemExit:
             raise
         except Exception as e:
-            message(f"Failed to initialize agent '{agent_name}': {e}", MessageType.ERROR, VerbosityLevel.ALWAYS)
+            message(
+                f"Failed to run agent '{agent_name}': {e}",
+                MessageType.ERROR,
+                VerbosityLevel.ALWAYS,
+            )
             sys.exit(1)

--- a/agent_manager/plugins/agents/__init__.py
+++ b/agent_manager/plugins/agents/__init__.py
@@ -1,5 +1,5 @@
 """Agent base classes and interfaces."""
 
-from .agent import AbstractAgent, ScopeConfig
+from .agent import AbstractAgent
 
-__all__ = ["AbstractAgent", "ScopeConfig"]
+__all__ = ["AbstractAgent"]

--- a/agent_manager/plugins/agents/agent.py
+++ b/agent_manager/plugins/agents/agent.py
@@ -1,87 +1,30 @@
-"""Abstract base class for AI agent plugins."""
+"""Abstract base class for AI agent plugins (V2 interface)."""
 
 import fnmatch
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from agent_manager.core import MergerRegistry
 from agent_manager.output import MessageType, VerbosityLevel, message
 
 
-@dataclass
-class ScopeConfig:
-    """Configuration for a single scope.
-
-    Attributes:
-        directory: The output directory for this scope
-        description: Human-readable description of the scope
-    """
-
-    directory: Path
-    description: str = ""
-
-
 class AbstractAgent(ABC):
-    """Base class for AI agent plugins with hierarchical configuration merging."""
+    """Base class for AI agent plugins with hierarchical configuration merging.
 
-    home_directory: Path = Path.home()
-    agent_directory: Path = home_directory
+    V2 interface: agents receive a base_directory and a list of repos.
+    The scope system has been removed.
+    """
 
     @property
     @abstractmethod
-    def scopes(self) -> dict:
-        """Define available scopes for this agent.
+    def agent_subdirectory(self) -> str:
+        """The subdirectory name this agent manages (e.g. '.claude', '.cursor').
 
-        Must be implemented by subclasses. Returns a dictionary mapping
-        scope names to ScopeConfig objects.
-
-        Example:
-            @property
-            def scopes(self) -> dict[str, ScopeConfig]:
-                return {
-                    "default": ScopeConfig(directory=Path.home() / ".myagent", description="..."),
-                    "user": ScopeConfig(directory=Path.home() / ".myagent", description="..."),
-                }
-
-        Returns:
-            Dictionary mapping scope names to ScopeConfig objects
+        This name is used both to discover files in repos and to determine
+        where merged output is written under the target directory.
         """
-        pass
-
-    # Default scope name
-    DEFAULT_SCOPE = "default"
-
-    def get_scope_names(self) -> list[str]:
-        """Get list of available scope names for this agent.
-
-        Returns:
-            Sorted list of scope names
-        """
-        return sorted(self.scopes.keys())
-
-    def get_scope_directory(self, scope: str | None = None) -> Path:
-        """Get the output directory for a specific scope.
-
-        Args:
-            scope: Scope name. If None, uses DEFAULT_SCOPE.
-
-        Returns:
-            Path to the scope's output directory
-
-        Raises:
-            ValueError: If the scope is not supported by this agent
-        """
-        if scope is None:
-            scope = self.DEFAULT_SCOPE
-
-        scopes = self.scopes
-        if scope not in scopes:
-            available = ", ".join(sorted(scopes.keys()))
-            raise ValueError(f"Unknown scope '{scope}'. Available scopes: {available}")
-
-        return scopes[scope].directory
 
     # Default files/directories to exclude when discovering configs
     BASE_EXCLUDE_PATTERNS = [
@@ -106,142 +49,202 @@ class AbstractAgent(ABC):
 
     def __init__(self):
         """Initialize the agent with hook registries and merger registry."""
-        # Hook registries: file_pattern -> hook_function
         self.pre_merge_hooks: dict[str, Callable] = {}
         self.post_merge_hooks: dict[str, Callable] = {}
 
-        # Build complete exclude patterns (base + agent-specific)
         self.exclude_patterns = self.BASE_EXCLUDE_PATTERNS.copy()
         self.exclude_patterns.extend(self.get_additional_excludes())
 
-        # Initialize merger registry with default mergers
         self.merger_registry = MergerRegistry()
         self.register_default_mergers()
 
-        # Register default hooks, then let agent plugins add custom ones
         self._register_default_hooks()
         self.register_hooks()
 
     def register_default_mergers(self) -> None:
-        """Register built-in mergers for common file types.
-
-        Uses late import to avoid circular dependency with agent_manager.
-        """
-        # Late import to avoid circular dependency
+        """Register built-in mergers for common file types."""
         from agent_manager.agent_manager import create_default_merger_registry
 
-        # Get a pre-configured registry and copy its registrations
         default_registry = create_default_merger_registry()
-        self.merger_registry.filename_mergers = default_registry.filename_mergers.copy()
-        self.merger_registry.extension_mergers = default_registry.extension_mergers.copy()
+        self.merger_registry.filename_mergers = (
+            default_registry.filename_mergers.copy()
+        )
+        self.merger_registry.extension_mergers = (
+            default_registry.extension_mergers.copy()
+        )
         self.merger_registry.default_merger = default_registry.default_merger
 
     def get_agent_name(self) -> str:
         """Get the display name for this agent.
 
-        Used in metadata headers and logging. Override to customize.
-        Default returns the agent directory name without the leading dot.
+        Returns the agent_subdirectory without the leading dot.
 
         Returns:
             Agent display name (e.g., "claude", "cursor")
         """
-        name = self.agent_directory.name
-        return name.lstrip(".")
+        return self.agent_subdirectory.lstrip(".")
 
+    # ------------------------------------------------------------------
+    # Hooks
+    # ------------------------------------------------------------------
     def _register_default_hooks(self) -> None:
-        """Register default hooks common to all agents.
-
-        Sets up markdown cleaning and metadata header generation.
-        Called before register_hooks() so plugins can override if needed.
-        """
-        # Pre-merge: Clean up markdown files
+        """Register default hooks common to all agents."""
         self.pre_merge_hooks["*.md"] = self._clean_markdown
-
-        # Post-merge: Add metadata header to merged files
         self.post_merge_hooks["*"] = self._add_metadata_header
 
     def register_hooks(self) -> None:  # noqa: B027
         """Register agent-specific hooks for pre/post merge processing.
 
-        Override this method to register additional hooks for specific file patterns.
-        Default hooks (markdown cleaning, metadata headers) are already registered.
-
-        Example:
-            def register_hooks(self) -> None:
-                self.pre_merge_hooks[".cursorrules"] = self._validate_cursorrules
-                self.post_merge_hooks["*.json"] = self._format_json
+        Override this method to register additional hooks.
         """
 
-    def _clean_markdown(self, content: str, entry: dict, file_path: Path) -> str:
-        """Clean up markdown content before merging.
-
-        Strips trailing whitespace and ensures single newline at end.
-
-        Args:
-            content: File content
-            entry: Hierarchy entry
-            file_path: Path to source file
-
-        Returns:
-            Cleaned content
-        """
+    def _clean_markdown(
+        self, content: str, repo_name: str, file_path: Path
+    ) -> str:
+        """Clean up markdown content before merging."""
         content = content.rstrip() + "\n"
-        message(f"    Cleaned markdown from {entry['name']}", MessageType.DEBUG, VerbosityLevel.DEBUG)
+        message(
+            f"    Cleaned markdown from {repo_name}",
+            MessageType.DEBUG,
+            VerbosityLevel.DEBUG,
+        )
         return content
 
-    def _add_metadata_header(self, content: str, file_name: str, sources: list[str]) -> str:
-        """Add metadata header to merged files with appropriate comment syntax.
-
-        Args:
-            content: Merged content
-            file_name: Output filename
-            sources: List of source hierarchy levels
-
-        Returns:
-            Content with metadata header
-        """
+    def _add_metadata_header(
+        self, content: str, file_name: str, sources: list[str]
+    ) -> str:
+        """Add metadata header to merged files."""
         file_lower = file_name.lower()
 
-        # JSON doesn't support comments, skip header
         if file_lower.endswith(".json"):
             return content
 
-        # Determine comment style based on file extension
-        if file_lower.endswith((".yaml", ".yml", ".txt", ".py", ".sh", ".cursorrules", ".clinerules")):
+        if file_lower.endswith(
+            (
+                ".yaml", ".yml", ".txt", ".py", ".sh",
+                ".cursorrules", ".clinerules",
+            )
+        ):
             comment_start = "# "
             comment_end = ""
-        elif file_lower.endswith((".md", ".markdown", ".html", ".xml")):
+        elif file_lower.endswith(
+            (".md", ".markdown", ".html", ".xml")
+        ):
             comment_start = "<!-- "
             comment_end = " -->"
         else:
             comment_start = "# "
             comment_end = ""
 
-        # Build header with appropriate comment syntax
         agent_name = self.get_agent_name()
-        header = f"{comment_start}Generated by agent-manager ({agent_name} agent){comment_end}\n"
-        header += f"{comment_start}File: {file_name}{comment_end}\n"
-        header += f"{comment_start}Sources: {' → '.join(sources)}{comment_end}\n"
-        header += (
-            f"{comment_start}Hierarchy: {sources[0]} (lowest) to {sources[-1]} (highest priority){comment_end}\n\n"
+        header = (
+            f"{comment_start}Generated by agent-manager "
+            f"({agent_name} agent){comment_end}\n"
         )
-
+        header += f"{comment_start}File: {file_name}{comment_end}\n"
+        header += (
+            f"{comment_start}Sources: "
+            f"{' → '.join(sources)}{comment_end}\n"
+        )
+        header += (
+            f"{comment_start}Hierarchy: {sources[0]} (lowest) to "
+            f"{sources[-1]} (highest priority){comment_end}\n\n"
+        )
         return header + content
 
-    def _initialize(self, scope: str | None = None) -> None:
-        """Initialize the agent's configuration directory.
+    # ------------------------------------------------------------------
+    # Excludes & root-level file discovery
+    # ------------------------------------------------------------------
+    def get_additional_excludes(self) -> list[str]:
+        """Get agent-specific exclude patterns.
 
-        Creates the output directory if it doesn't exist. Override this method
-        for agent-specific initialization (e.g., running SDK commands).
+        Returns:
+            List of additional patterns to exclude (default: empty list)
+        """
+        return []
+
+    def get_additional_root_level_files(self) -> list[str]:
+        """Get additional root-level files beyond BASE_ROOT_LEVEL_FILES.
+
+        Override to add agent-specific root-level files.
+
+        Returns:
+            List of filenames to discover at repository root
+        """
+        return []
+
+    def _get_root_level_files(self) -> list[str]:
+        """Get complete list of root-level files to discover.
+
+        Combines BASE_ROOT_LEVEL_FILES with get_additional_root_level_files().
+        """
+        if not hasattr(self, "_cached_root_level_files"):
+            self._cached_root_level_files = (
+                self.BASE_ROOT_LEVEL_FILES
+                + self.get_additional_root_level_files()
+            )
+        return self._cached_root_level_files
+
+    # ------------------------------------------------------------------
+    # File discovery
+    # ------------------------------------------------------------------
+    def _discover_files(self, repo_path: Path) -> list[Path]:
+        """Discover configuration files from a repository.
+
+        Searches for:
+        1. Root-level files (AGENTS.md, CLAUDE.md, etc.)
+        2. Agent subdirectory files (repo/<agent_subdirectory>/...)
+
+        Root-level files sort first so subdirectory files can override them.
 
         Args:
-            scope: Scope to initialize. If None, uses default scope.
-        """
-        output_dir = self.get_scope_directory(scope)
+            repo_path: Path to the repository
 
+        Returns:
+            Sorted list of configuration file paths
+        """
+        found_files: list[Path] = []
+
+        # Root-level files
+        for filename in self._get_root_level_files():
+            file_path = repo_path / filename
+            if file_path.exists() and file_path.is_file():
+                found_files.append(file_path)
+
+        # Agent subdirectory files
+        agent_repo_dir = repo_path / self.agent_subdirectory
+        if agent_repo_dir.exists() and agent_repo_dir.is_dir():
+            for item in agent_repo_dir.rglob("*"):
+                if item.is_dir():
+                    continue
+                if any(
+                    fnmatch.fnmatch(item.name, p)
+                    for p in self.exclude_patterns
+                ):
+                    continue
+                found_files.append(item)
+
+        def sort_key(path: Path) -> tuple:
+            is_subdirectory = path.parent != repo_path
+            return (is_subdirectory, path.name)
+
+        return sorted(found_files, key=sort_key)
+
+    # ------------------------------------------------------------------
+    # Initialize / Update / Merge
+    # ------------------------------------------------------------------
+    def _initialize(self, output_dir: Path) -> None:
+        """Ensure the output directory exists.
+
+        Override for agent-specific initialization (e.g. running SDK commands).
+
+        Args:
+            output_dir: The directory to ensure exists
+        """
         if output_dir.exists():
             message(
-                f"{self.get_agent_name()} directory already exists: {output_dir}",
+                f"{self.get_agent_name()} directory already exists: "
+                f"{output_dir}",
                 MessageType.DEBUG,
                 VerbosityLevel.DEBUG,
             )
@@ -252,298 +255,205 @@ class AbstractAgent(ABC):
             MessageType.INFO,
             VerbosityLevel.EXTRA_VERBOSE,
         )
-
         output_dir.mkdir(parents=True, exist_ok=True)
-        message(f"✓ Created {output_dir}", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
+        message(
+            f"Created {output_dir}",
+            MessageType.SUCCESS,
+            VerbosityLevel.ALWAYS,
+        )
 
-    def update(self, config: dict, scope: str | None = None) -> None:
-        """Update agent configuration from hierarchical repositories.
-
-        Default implementation initializes the directory and merges configurations.
-        Override for agent-specific update behavior.
-
-        Args:
-            config: Configuration data with hierarchy and repo objects
-            scope: Configuration scope to use. If None, uses default scope.
-        """
-        self._initialize(scope)
-        self.merge_configurations(config, scope)
-
-    def get_additional_excludes(self) -> list[str]:
-        """Get agent-specific exclude patterns.
-
-        Override this method to add additional patterns to exclude when discovering files.
-        These will be added to BASE_EXCLUDE_PATTERNS.
-
-        Returns:
-            List of additional patterns to exclude (default: empty list)
-        """
-        return []
-
-    def get_additional_root_level_files(self) -> list[str]:
-        """Get additional root-level files to discover beyond BASE_ROOT_LEVEL_FILES.
-
-        Override this method in agent plugins to add agent-specific root-level files.
-        For example, the Claude agent adds "CLAUDE.md".
-
-        Returns:
-            List of filenames to discover at repository root (e.g., ["CLAUDE.md"])
-
-        Example:
-            class ClaudeAgent(AbstractAgent):
-                def get_additional_root_level_files(self) -> list[str]:
-                    return ["CLAUDE.md"]
-        """
-        return []
-
-    def _get_root_level_files(self) -> list[str]:
-        """Get complete list of root-level files to discover.
-
-        Combines BASE_ROOT_LEVEL_FILES with agent-specific files from
-        get_additional_root_level_files(). Result is cached per agent instance.
-
-        Returns:
-            Combined list of filenames to discover at repository root
-        """
-        if not hasattr(self, "_cached_root_level_files"):
-            self._cached_root_level_files = self.BASE_ROOT_LEVEL_FILES + self.get_additional_root_level_files()
-        return self._cached_root_level_files
-
-    def get_repo_directory_name(self, scope: str | None = None) -> str:
-        """Get the directory name to look for in repositories.
-
-        By default, uses the name of the scope's directory (e.g., ".claude" from ~/.claude).
-        If _repo_directory_name is set, uses that instead (useful for testing).
+    def update(
+        self,
+        repos: list[dict[str, Any]],
+        base_directory: Path,
+        merger_settings: dict[str, Any] | None = None,
+    ) -> None:
+        """Update agent configuration in the given base directory.
 
         Args:
-            scope: Scope name. If None, uses DEFAULT_SCOPE.
-
-        Returns:
-            Directory name to search for in repositories
+            repos: Ordered list of repo entries (lowest to highest priority).
+                   Each must have 'name' and 'repo' keys.
+            base_directory: Resolved target directory (e.g. Path.home()).
+            merger_settings: Optional dict of per-merger settings from config.
         """
-        repo_dir_name = getattr(self, "_repo_directory_name", None)
-        if repo_dir_name:
-            return repo_dir_name
-        return self.get_scope_directory(scope).name
+        output_dir = base_directory / self.agent_subdirectory
+        self._initialize(output_dir)
+        self.merge_configurations(repos, base_directory, merger_settings)
 
-    def _discover_files(self, repo_path: Path, scope: str | None = None) -> list[Path]:
-        """Discover configuration files from repository.
+    def merge_configurations(
+        self,
+        repos: list[dict[str, Any]],
+        base_directory: Path,
+        merger_settings: dict[str, Any] | None = None,
+    ) -> None:
+        """Merge configuration files from repos into the base directory.
 
-        Searches for files in two locations:
-        1. Root-level files: AGENTS.md, CLAUDE.md, etc. (defined by BASE_ROOT_LEVEL_FILES
-           and get_additional_root_level_files())
-        2. Agent subdirectory: <repo_path>/<agent_directory_name>/ (e.g., repo/.claude/)
-
-        Root-level files are discovered first, ensuring they merge BEFORE agent subdirectory
-        files when both exist with the same filename. This allows subdirectory files to
-        override/extend root-level files.
+        Root-level files (AGENTS.md etc.) are written to base_directory.
+        Agent subdirectory files are written to base_directory/<agent_subdirectory>.
 
         Args:
-            repo_path: Path to the repository
-            scope: Scope name for determining which directory to look in
-
-        Returns:
-            List of configuration file paths (root-level files first, then subdirectory files)
+            repos: Ordered list of repo entries (lowest to highest priority).
+            base_directory: Resolved target directory.
+            merger_settings: Optional per-merger settings.
         """
-        found_files = []
+        if merger_settings is None:
+            merger_settings = {}
 
-        # === Discover root-level files ===
-        root_level_files = self._get_root_level_files()
-        for filename in root_level_files:
-            file_path = repo_path / filename
-            if file_path.exists() and file_path.is_file():
-                found_files.append(file_path)
+        message(
+            f"\n=== Merging {self.get_agent_name()} configurations ===",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+        message(
+            f"Output: {base_directory}",
+            MessageType.INFO,
+            VerbosityLevel.VERBOSE,
+        )
 
-        # === Discover agent subdirectory files ===
-        agent_dir_name = self.get_repo_directory_name(scope)
-        agent_repo_dir = repo_path / agent_dir_name
-
-        if agent_repo_dir.exists() and agent_repo_dir.is_dir():
-            # Recursively find all files in the agent directory
-            for item in agent_repo_dir.rglob("*"):
-                if item.is_dir():
-                    continue
-
-                should_exclude = False
-                for pattern in self.exclude_patterns:
-                    if fnmatch.fnmatch(item.name, pattern):
-                        should_exclude = True
-                        break
-
-                if not should_exclude:
-                    found_files.append(item)
-
-        def sort_key(path: Path) -> tuple:
-            """Sort root-level files before subdirectory files, then by name."""
-            is_subdirectory = path.parent != repo_path
-            return (is_subdirectory, path.name)
-
-        return sorted(found_files, key=sort_key)
-
-    def get_agent_directory(self, scope: str | None = None) -> Path:
-        """Get the agent's configuration directory.
-
-        Args:
-            scope: Scope name. If None, uses DEFAULT_SCOPE.
-
-        Returns:
-            Path to the agent directory for the given scope
-        """
-        return self.get_scope_directory(scope)
-
-    def _should_include_entry_for_scope(self, entry: dict, scope: str) -> bool:
-        """Check if a hierarchy entry should be included for the given scope.
-
-        If the entry has a 'scopes' key, only include it if the scope is in that list.
-        If no 'scopes' key is present, include the entry for all scopes.
-
-        Args:
-            entry: Hierarchy entry from config
-            scope: Current scope being processed
-
-        Returns:
-            True if the entry should be included, False otherwise
-        """
-        entry_scopes = entry.get("scopes")
-        if entry_scopes is None:
-            # No scopes specified = applies to all scopes
-            return True
-        return scope in entry_scopes
-
-    def merge_configurations(self, config: dict, scope: str | None = None) -> None:
-        """Merge configuration files from hierarchical repositories.
-
-        Traverses the hierarchy (org -> team -> personal) and merges files
-        with type-aware strategies and hook support.
-
-        Args:
-            config: Configuration data with hierarchy and repo objects
-            scope: Scope to merge for. If None, uses DEFAULT_SCOPE.
-        """
-        if scope is None:
-            scope = self.DEFAULT_SCOPE
-
-        # Validate scope
-        output_dir = self.get_scope_directory(scope)
-        scope_config = self.scopes[scope]
-
-        message(f"\n=== Merging Configurations for scope '{scope}' ===", MessageType.NORMAL, VerbosityLevel.ALWAYS)
-        message(f"Output directory: {output_dir}", MessageType.INFO, VerbosityLevel.VERBOSE)
-        if scope_config.description:
-            message(f"({scope_config.description})\n", MessageType.NORMAL, VerbosityLevel.VERBOSE)
-
-        # Track merged files: filename -> (content, source_info_list)
+        # file_key -> (content, source_names)
         merged_files: dict[str, tuple[str, list[str]]] = {}
 
-        # Process hierarchy from lowest to highest priority (org -> team -> personal)
-        for entry in config["hierarchy"]:
-            # Check if this entry applies to the current scope
-            if not self._should_include_entry_for_scope(entry, scope):
-                message(
-                    f"Skipping '{entry['name']}' (not in scope '{scope}')",
-                    MessageType.DEBUG,
-                    VerbosityLevel.DEBUG,
-                )
-                continue
-
+        for entry in repos:
             name = entry["name"]
             repo = entry["repo"]
             repo_path = repo.get_path()
 
-            message(f"Processing '{name}' repository...", MessageType.INFO, VerbosityLevel.EXTRA_VERBOSE)
-            message(f"  Path: {repo_path}", MessageType.DEBUG, VerbosityLevel.DEBUG)
+            message(
+                f"Processing '{name}' repository...",
+                MessageType.INFO,
+                VerbosityLevel.EXTRA_VERBOSE,
+            )
 
-            # Check if repository exists locally
             if not repo_path.exists():
-                message(f"  Repository path does not exist: {repo_path}", MessageType.WARNING, VerbosityLevel.ALWAYS)
+                message(
+                    f"  Repository path does not exist: {repo_path}",
+                    MessageType.WARNING,
+                    VerbosityLevel.ALWAYS,
+                )
                 continue
 
-            # Discover files in this repository
-            files = self._discover_files(repo_path, scope)
-
+            files = self._discover_files(repo_path)
             if not files:
-                message(f"  No configuration files found in '{name}'", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+                message(
+                    f"  No configuration files found in '{name}'",
+                    MessageType.NORMAL,
+                    VerbosityLevel.ALWAYS,
+                )
                 continue
 
-            message(f"  Found {len(files)} file(s)", MessageType.DEBUG, VerbosityLevel.DEBUG)
+            message(
+                f"  Found {len(files)} file(s)",
+                MessageType.DEBUG,
+                VerbosityLevel.DEBUG,
+            )
+
+            agent_repo_dir = repo_path / self.agent_subdirectory
 
             for file_path in files:
-                # Get relative path from agent directory in repo
-                # e.g., repo/.claude/agents/JIRA.md -> agents/JIRA.md
-                agent_repo_dir = repo_path / self.get_repo_directory_name(scope)
+                # Determine the file key (relative output path)
                 try:
                     relative_path = file_path.relative_to(agent_repo_dir)
-                    file_key = str(relative_path)  # Use relative path as key
+                    file_key = str(
+                        Path(self.agent_subdirectory) / relative_path
+                    )
                 except ValueError:
-                    # Fallback to just filename if relative_to fails
+                    # Root-level file (e.g. AGENTS.md)
                     file_key = file_path.name
 
                 try:
                     content = file_path.read_text()
-                    message(f"    Processing: {file_key}", MessageType.DEBUG, VerbosityLevel.DEBUG)
+                    message(
+                        f"    Processing: {file_key}",
+                        MessageType.DEBUG,
+                        VerbosityLevel.DEBUG,
+                    )
 
-                    # PRE-MERGE HOOK: Allow plugin-specific preprocessing
-                    content = self._run_hook(self.pre_merge_hooks, file_key, content, entry, file_path)
+                    # Pre-merge hook
+                    content = self._run_hook(
+                        self.pre_merge_hooks, file_key,
+                        content, name, file_path,
+                    )
 
-                    # Merge with existing content for this file (by relative path)
                     if file_key in merged_files:
                         existing_content, sources = merged_files[file_key]
-
-                        # Get appropriate merger for this file
-                        merger_class = self.merger_registry.get_merger(file_path)
-
-                        # Get merger settings from config
-                        merger_settings = config.get("mergers", {}).get(merger_class.__name__, {})
-
-                        # Merge using the registered merger
-                        merged_content = merger_class.merge(existing_content, content, name, sources, **merger_settings)
+                        merger_class = self.merger_registry.get_merger(
+                            file_path
+                        )
+                        settings = merger_settings.get(
+                            merger_class.__name__, {}
+                        )
+                        merged_content = merger_class.merge(
+                            existing_content, content,
+                            name, sources, **settings,
+                        )
                         sources.append(name)
                         merged_files[file_key] = (merged_content, sources)
                     else:
-                        # First occurrence of this file
                         merged_files[file_key] = (content, [name])
 
                 except Exception as e:
-                    message(f"    Could not process {file_key}: {e}", MessageType.WARNING, VerbosityLevel.ALWAYS)
+                    message(
+                        f"    Could not process {file_key}: {e}",
+                        MessageType.WARNING,
+                        VerbosityLevel.ALWAYS,
+                    )
 
-            message(f"  ✓ Processed '{name}'", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
+            message(
+                f"  Processed '{name}'",
+                MessageType.SUCCESS,
+                VerbosityLevel.ALWAYS,
+            )
 
-        # Write merged files with POST-MERGE HOOKS
+        # Write merged files
         if merged_files:
             message(
-                f"\nWriting {len(merged_files)} merged file(s) to {output_dir}...",
+                f"\nWriting {len(merged_files)} merged file(s)...",
                 MessageType.NORMAL,
                 VerbosityLevel.ALWAYS,
             )
 
-            for file_path_str, (content, sources) in merged_files.items():
-                # POST-MERGE HOOK: Allow plugin-specific postprocessing
-                content = self._run_hook(self.post_merge_hooks, file_path_str, content, None, None, sources)
+            for file_key, (content, sources) in merged_files.items():
+                content = self._run_hook(
+                    self.post_merge_hooks, file_key,
+                    content, None, None, sources,
+                )
 
-                # Preserve directory structure: use relative path as-is
-                output_path = output_dir / file_path_str
+                output_path = base_directory / file_key
                 try:
-                    # Ensure parent directories exist
                     output_path.parent.mkdir(parents=True, exist_ok=True)
                     output_path.write_text(content)
                     message(
-                        f"  ✓ Wrote {file_path_str} (from {len(sources)} source(s): {', '.join(sources)})",
+                        f"  Wrote {file_key} "
+                        f"(from {len(sources)} source(s): "
+                        f"{', '.join(sources)})",
                         MessageType.SUCCESS,
                         VerbosityLevel.ALWAYS,
                     )
                 except Exception as e:
-                    message(f"  ✗ Failed to write {file_path_str}: {e}", MessageType.ERROR, VerbosityLevel.ALWAYS)
+                    message(
+                        f"  Failed to write {file_key}: {e}",
+                        MessageType.ERROR,
+                        VerbosityLevel.ALWAYS,
+                    )
         else:
-            message("No configuration files found in any hierarchy level", MessageType.WARNING, VerbosityLevel.ALWAYS)
+            message(
+                "No configuration files found in any repository",
+                MessageType.WARNING,
+                VerbosityLevel.ALWAYS,
+            )
 
-        message("\n✓ Configuration merge complete!", MessageType.SUCCESS, VerbosityLevel.ALWAYS)
+        message(
+            "\nConfiguration merge complete!",
+            MessageType.SUCCESS,
+            VerbosityLevel.ALWAYS,
+        )
 
     def _run_hook(
         self,
         hooks: dict[str, Callable],
         file_name: str,
         content: str,
-        entry: dict | None,
+        repo_name: str | None,
         file_path: Path | None,
         sources: list[str] | None = None,
     ) -> str:
@@ -551,11 +461,11 @@ class AbstractAgent(ABC):
 
         Args:
             hooks: Hook registry to search
-            file_name: Name of the file
+            file_name: Name/key of the file
             content: Current content
-            entry: Hierarchy entry (None for post-merge)
+            repo_name: Repo name (for pre-merge hooks, None for post-merge)
             file_path: Path to source file (None for post-merge)
-            sources: List of sources (for post-merge hooks)
+            sources: List of source names (for post-merge hooks)
 
         Returns:
             Possibly modified content
@@ -563,16 +473,14 @@ class AbstractAgent(ABC):
         for pattern, hook_func in hooks.items():
             if fnmatch.fnmatch(file_name, pattern):
                 try:
-                    # Call hook with available context
                     if sources is not None:
-                        # Post-merge hook signature
                         content = hook_func(content, file_name, sources)
                     else:
-                        # Pre-merge hook signature
-                        content = hook_func(content, entry, file_path)
+                        content = hook_func(content, repo_name, file_path)
                 except Exception as e:
                     message(
-                        f"  Hook error for {file_name} (pattern: {pattern}): {e}",
+                        f"  Hook error for {file_name} "
+                        f"(pattern: {pattern}): {e}",
                         MessageType.WARNING,
                         VerbosityLevel.ALWAYS,
                     )

--- a/tests/cli_extensions/test_agent_commands.py
+++ b/tests/cli_extensions/test_agent_commands.py
@@ -1,274 +1,191 @@
-"""Tests for cli_extensions/agent_commands.py - Agent CLI commands."""
+"""Tests for cli_extensions/agent_commands.py - Agent CLI commands (V2)."""
 
+from pathlib import Path
 from unittest.mock import Mock, patch
+
+import pytest
 
 from agent_manager.cli_extensions.agent_commands import AgentCommands
 
 
 class TestAgentCommandsAddCliArguments:
-    """Test cases for add_cli_arguments method."""
 
     @patch("agent_manager.cli_extensions.agent_commands.get_agent_names")
-    def test_adds_agents_and_run_parsers(self, mock_get_agent_names):
-        """Test that add_cli_arguments adds both agents and run parsers."""
-        mock_get_agent_names.return_value = ["claude"]
-
+    def test_adds_agents_and_run_parsers(self, mock_names):
+        mock_names.return_value = ["claude"]
         mock_subparsers = Mock()
         mock_parser = Mock()
-        mock_agents_subparsers = Mock()
-        mock_parser.add_subparsers.return_value = mock_agents_subparsers
+        mock_parser.add_subparsers.return_value = Mock()
         mock_subparsers.add_parser.return_value = mock_parser
 
         AgentCommands.add_cli_arguments(mock_subparsers)
 
-        # Should add both "agents" and "run" parsers
-        calls = [call[0][0] for call in mock_subparsers.add_parser.call_args_list]
+        calls = [c[0][0] for c in mock_subparsers.add_parser.call_args_list]
         assert "agents" in calls
         assert "run" in calls
 
     @patch("agent_manager.cli_extensions.agent_commands.get_agent_names")
-    def test_adds_agents_list_subcommand(self, mock_get_agent_names):
-        """Test that add_cli_arguments adds list, enable, and disable subcommands to agents."""
-        mock_get_agent_names.return_value = ["claude"]
-
+    def test_adds_agents_subcommands(self, mock_names):
+        mock_names.return_value = ["claude"]
         mock_subparsers = Mock()
         mock_agents_parser = Mock()
-        mock_agents_subparsers = Mock()
-        mock_run_parser = Mock()
+        mock_agents_sub = Mock()
+        mock_agents_parser.add_subparsers.return_value = mock_agents_sub
 
-        def add_parser_side_effect(name, **kwargs):
+        def side_effect(name, **kwargs):
             if name == "agents":
                 return mock_agents_parser
-            elif name == "run":
-                return mock_run_parser
             return Mock()
 
-        mock_subparsers.add_parser.side_effect = add_parser_side_effect
-        mock_agents_parser.add_subparsers.return_value = mock_agents_subparsers
+        mock_subparsers.add_parser.side_effect = side_effect
 
         AgentCommands.add_cli_arguments(mock_subparsers)
 
-        # Check that all three subcommands were added to agents
-        calls = [call[0][0] for call in mock_agents_subparsers.add_parser.call_args_list]
+        calls = [c[0][0] for c in mock_agents_sub.add_parser.call_args_list]
         assert "list" in calls
         assert "enable" in calls
         assert "disable" in calls
 
     @patch("agent_manager.cli_extensions.agent_commands.get_agent_names")
-    def test_adds_agent_argument_with_choices(self, mock_get_agent_names):
-        """Test that agent argument includes discovered plugins."""
-        mock_get_agent_names.return_value = ["claude", "custom"]
-
+    def test_run_has_agent_choices(self, mock_names):
+        mock_names.return_value = ["claude", "custom"]
         mock_subparsers = Mock()
-        mock_agents_parser = Mock()
-        mock_run_parser = Mock()
-        mock_agents_parser.add_subparsers.return_value = Mock()
+        mock_run = Mock()
 
-        def add_parser_side_effect(name, **kwargs):
-            if name == "agents":
-                return mock_agents_parser
-            elif name == "run":
-                return mock_run_parser
-            return Mock()
+        def side_effect(name, **kwargs):
+            if name == "run":
+                return mock_run
+            m = Mock()
+            m.add_subparsers.return_value = Mock()
+            return m
 
-        mock_subparsers.add_parser.side_effect = add_parser_side_effect
+        mock_subparsers.add_parser.side_effect = side_effect
 
         AgentCommands.add_cli_arguments(mock_subparsers)
 
-        # Check that add_argument was called on run parser with choices including discovered agents
-        call_args = mock_run_parser.add_argument.call_args_list
-        # Find the --agent argument
-        agent_arg = None
-        for call in call_args:
-            if len(call[0]) > 0 and call[0][0] == "--agent":
-                agent_arg = call
-                break
-        assert agent_arg is not None
-        assert agent_arg[1]["choices"] == ["all", "claude", "custom"]
+        for call in mock_run.add_argument.call_args_list:
+            if call[0] and call[0][0] == "--agent":
+                assert call[1]["choices"] == ["all", "claude", "custom"]
+                return
+        pytest.fail("--agent argument not found")
 
     @patch("agent_manager.cli_extensions.agent_commands.get_agent_names")
-    def test_adds_agent_argument_with_no_plugins(self, mock_get_agent_names):
-        """Test that agent argument works with no plugins."""
-        mock_get_agent_names.return_value = []
-
+    def test_no_scope_argument(self, mock_names):
+        """--scope was removed in V2."""
+        mock_names.return_value = []
         mock_subparsers = Mock()
-        mock_agents_parser = Mock()
-        mock_run_parser = Mock()
-        mock_agents_parser.add_subparsers.return_value = Mock()
+        mock_run = Mock()
 
-        def add_parser_side_effect(name, **kwargs):
-            if name == "agents":
-                return mock_agents_parser
-            elif name == "run":
-                return mock_run_parser
-            return Mock()
+        def side_effect(name, **kwargs):
+            if name == "run":
+                return mock_run
+            m = Mock()
+            m.add_subparsers.return_value = Mock()
+            return m
 
-        mock_subparsers.add_parser.side_effect = add_parser_side_effect
+        mock_subparsers.add_parser.side_effect = side_effect
 
         AgentCommands.add_cli_arguments(mock_subparsers)
 
-        # Should still add argument with just "all"
-        call_args = mock_run_parser.add_argument.call_args_list
-        # Find the --agent argument
-        agent_arg = None
-        for call in call_args:
-            if len(call[0]) > 0 and call[0][0] == "--agent":
-                agent_arg = call
-                break
-        assert agent_arg is not None
-        assert agent_arg[1]["choices"] == ["all"]
+        for call in mock_run.add_argument.call_args_list:
+            if call[0] and call[0][0] == "--scope":
+                pytest.fail("--scope should not exist in V2")
 
 
 class TestAgentCommandsProcessCliCommand:
-    """Test cases for process_cli_command method."""
 
     @patch("agent_manager.cli_extensions.agent_commands.run_agents")
-    def test_processes_run_command_single_agent(self, mock_run_agents):
-        """Test processing run command for single agent."""
+    @patch("agent_manager.cli_extensions.agent_commands.message")
+    def test_calls_run_agents_with_v2_signature(self, mock_msg, mock_run):
         args = Mock()
         args.agent = "claude"
-        args.scope = "default"
-        config_data = {"hierarchy": []}
+        config_data = {
+            "repos": [{"name": "org", "url": "x", "repo_type": "git"}],
+            "mergers": {"JsonMerger": {"indent": 2}},
+        }
 
         AgentCommands.process_cli_command(args, config_data)
 
-        mock_run_agents.assert_called_once_with(["claude"], config_data, scope="default")
+        mock_run.assert_called_once()
+        call_args = mock_run.call_args
+        assert call_args[0][0] == ["claude"]
+        assert call_args[0][1] == config_data["repos"]
+        assert isinstance(call_args[0][2], Path)
+        assert call_args[0][3] == {"JsonMerger": {"indent": 2}}
 
     @patch("agent_manager.cli_extensions.agent_commands.run_agents")
-    def test_processes_run_command_all_agents(self, mock_run_agents):
-        """Test processing run command for all agents."""
+    @patch("agent_manager.cli_extensions.agent_commands.message")
+    def test_all_agents(self, mock_msg, mock_run):
         args = Mock()
         args.agent = "all"
-        args.scope = "default"
-        config_data = {"hierarchy": []}
+        config_data = {"repos": [], "mergers": {}}
 
         AgentCommands.process_cli_command(args, config_data)
 
-        mock_run_agents.assert_called_once_with(["all"], config_data, scope="default")
+        mock_run.assert_called_once()
+        assert mock_run.call_args[0][0] == ["all"]
 
 
 class TestAgentCommandsProcessAgentsCommand:
-    """Test cases for process_agents_command method."""
 
-    def test_no_subcommand_specified(self):
-        """Test that no subcommand shows friendly usage message."""
+    def test_no_subcommand(self):
         args = Mock()
         args.agents_command = None
-
         messages = []
 
-        def capture_message(text, *args_inner, **kwargs):
-            messages.append(text)
-
-        with patch("agent_manager.cli_extensions.agent_commands.message", side_effect=capture_message):
-            AgentCommands.process_agents_command(args)
-
-        output = "\n".join(messages)
-        assert "Usage: agent-manager agents <command>" in output
-        assert "Available commands:" in output
-        assert "list" in output
-        assert "enable" in output
-        assert "disable" in output
-
-    def test_no_agents_command_attribute(self):
-        """Test that missing agents_command attribute shows friendly usage."""
-        args = Mock(spec=[])  # Mock with no attributes
-
-        messages = []
-
-        def capture_message(text, *args_inner, **kwargs):
-            messages.append(text)
-
-        with patch("agent_manager.cli_extensions.agent_commands.message", side_effect=capture_message):
+        with patch(
+            "agent_manager.cli_extensions.agent_commands.message",
+            side_effect=lambda t, *a, **kw: messages.append(t),
+        ):
             AgentCommands.process_agents_command(args)
 
         output = "\n".join(messages)
         assert "Usage: agent-manager agents <command>" in output
 
-    @patch("agent_manager.cli_extensions.agent_commands.AgentCommands.list_agents")
-    def test_processes_list_command(self, mock_list_agents):
-        """Test that list command calls list_agents."""
+    @patch(
+        "agent_manager.cli_extensions.agent_commands"
+        ".AgentCommands.list_agents",
+    )
+    def test_list(self, mock_list):
         args = Mock()
         args.agents_command = "list"
-
         AgentCommands.process_agents_command(args)
-
-        mock_list_agents.assert_called_once()
+        mock_list.assert_called_once()
 
 
 class TestAgentCommandsListAgents:
-    """Test cases for list_agents method."""
 
     @patch("agent_manager.cli_extensions.agent_commands.get_disabled_plugins")
     @patch("agent_manager.cli_extensions.agent_commands.discover_agent_plugins")
-    def test_list_agents_with_plugins(self, mock_discover, mock_get_disabled):
-        """Test listing agents when plugins are available."""
-        mock_discover.return_value = {
+    def test_with_plugins(self, mock_disc, mock_disabled):
+        mock_disc.return_value = {
             "claude": {"package_name": "am_agent_claude", "source": "package"},
-            "custom": {"package_name": "am_agent_custom", "source": "package"},
         }
-        mock_get_disabled.return_value = {"agents": []}
-
+        mock_disabled.return_value = {"agents": []}
         messages = []
 
-        def capture_message(text, *args, **kwargs):
-            messages.append(text)
-
-        with patch("agent_manager.cli_extensions.agent_commands.message", side_effect=capture_message):
+        with patch(
+            "agent_manager.cli_extensions.agent_commands.message",
+            side_effect=lambda t, *a, **kw: messages.append(t),
+        ):
             AgentCommands.list_agents()
 
-        # Check that agents are listed
         output = "\n".join(messages)
         assert "claude" in output
         assert "am_agent_claude" in output
-        assert "custom" in output
-        assert "am_agent_custom" in output
-        assert "Total: 2 enabled, 0 disabled" in output
 
     @patch("agent_manager.cli_extensions.agent_commands.get_disabled_plugins")
     @patch("agent_manager.cli_extensions.agent_commands.discover_agent_plugins")
-    def test_list_agents_no_plugins(self, mock_discover, mock_get_disabled):
-        """Test listing agents when no plugins are available."""
-        mock_discover.return_value = {}
-        mock_get_disabled.return_value = {"agents": []}
-
+    def test_no_plugins(self, mock_disc, mock_disabled):
+        mock_disc.return_value = {}
+        mock_disabled.return_value = {"agents": []}
         messages = []
 
-        def capture_message(text, *args, **kwargs):
-            messages.append(text)
-
-        with patch("agent_manager.cli_extensions.agent_commands.message", side_effect=capture_message):
+        with patch(
+            "agent_manager.cli_extensions.agent_commands.message",
+            side_effect=lambda t, *a, **kw: messages.append(t),
+        ):
             AgentCommands.list_agents()
 
-        # Check that appropriate message is shown
         output = "\n".join(messages)
         assert "No agent plugins found" in output
-        assert "am_agent_" in output  # Should mention the plugin naming convention
-
-    @patch("agent_manager.cli_extensions.agent_commands.get_disabled_plugins")
-    @patch("agent_manager.cli_extensions.agent_commands.discover_agent_plugins")
-    def test_list_agents_sorted(self, mock_discover, mock_get_disabled):
-        """Test that agents are listed in sorted order."""
-        mock_discover.return_value = {
-            "zebra": {"package_name": "am_agent_zebra", "source": "package"},
-            "alpha": {"package_name": "am_agent_alpha", "source": "package"},
-            "middle": {"package_name": "am_agent_middle", "source": "package"},
-        }
-        mock_get_disabled.return_value = {"agents": []}
-
-        messages = []
-
-        def capture_message(text, *args, **kwargs):
-            messages.append(text)
-
-        with patch("agent_manager.cli_extensions.agent_commands.message", side_effect=capture_message):
-            AgentCommands.list_agents()
-
-        # Find lines that contain agent names
-        agent_lines = [m for m in messages if "am_agent_" in m and "(" in m]
-
-        # Should be in alphabetical order
-        assert len(agent_lines) == 3
-        assert "alpha" in agent_lines[0]
-        assert "middle" in agent_lines[1]
-        assert "zebra" in agent_lines[2]

--- a/tests/cli_extensions/test_config_commands.py
+++ b/tests/cli_extensions/test_config_commands.py
@@ -1,5 +1,6 @@
-"""Tests for cli_extensions/config_commands.py - Config CLI commands."""
+"""Tests for cli_extensions/config_commands.py - V2 Config CLI commands."""
 
+import argparse
 from unittest.mock import Mock, patch
 
 import pytest
@@ -10,302 +11,146 @@ from agent_manager.config.config import Config
 
 
 class TestConfigCommandsAddCliArguments:
-    """Test cases for add_cli_arguments method."""
+    """Test that all V2 subcommands are registered."""
 
     def test_adds_config_parser(self):
-        """Test that config parser is added."""
         mock_subparsers = Mock()
         mock_parser = Mock()
         mock_subparsers.add_parser.return_value = mock_parser
-
         ConfigCommands.add_cli_arguments(mock_subparsers)
-
-        # Should add config parser
         assert mock_subparsers.add_parser.called
 
-    def test_adds_all_subcommands(self):
-        """Test that all config subcommands are added."""
-        import argparse
-
+    def test_adds_expected_subcommands(self):
         parser = argparse.ArgumentParser()
         subparsers = parser.add_subparsers(dest="command")
-
         ConfigCommands.add_cli_arguments(subparsers)
 
-        # Parse each subcommand to verify they exist
-        commands = ["init", "show", "add", "remove", "update", "move", "validate", "export", "import", "where"]
-
-        for cmd in commands:
-            if cmd in ["add", "remove", "update", "move", "import"]:
-                # These require additional arguments
-                continue
+        # Commands that don't require positional args
+        for cmd in ["show", "validate", "template", "where", "init", "edit"]:
             args = parser.parse_args(["config", cmd])
-            assert args.command == "config"
             assert args.config_command == cmd
 
 
 class TestConfigCommandsProcessCliCommand:
-    """Test cases for process_cli_command method."""
-
-    def test_processes_init_command(self):
-        """Test processing of init command."""
-        args = Mock()
-        args.config_command = "init"
-
-        config = Mock(spec=Config)
-
-        ConfigCommands.process_cli_command(args, config)
-
-        config.initialize.assert_called_once_with(skip_if_already_created=False)
 
     @patch("agent_manager.cli_extensions.config_commands.ConfigCommands.display")
-    def test_processes_show_command(self, mock_display):
-        """Test processing of show command."""
-        args = Mock()
-        args.config_command = "show"
-        args.resolve_paths = False
-
+    def test_show(self, mock_display):
+        args = Mock(config_command="show")
         config = Mock(spec=Config)
-
         ConfigCommands.process_cli_command(args, config)
-
-        mock_display.assert_called_once_with(config, resolve_paths=False)
-
-    @patch("agent_manager.cli_extensions.config_commands.ConfigCommands.display")
-    def test_processes_show_command_with_resolve(self, mock_display):
-        """Test processing of show command with resolve_paths."""
-        args = Mock()
-        args.config_command = "show"
-        args.resolve_paths = True
-
-        config = Mock(spec=Config)
-
-        ConfigCommands.process_cli_command(args, config)
-
-        mock_display.assert_called_once_with(config, resolve_paths=True)
-
-    def test_processes_add_command(self):
-        """Test processing of add command."""
-        args = Mock()
-        args.config_command = "add"
-        args.name = "team"
-        args.url = "https://github.com/team/repo"
-        args.position = None
-
-        config = Mock(spec=Config)
-
-        ConfigCommands.process_cli_command(args, config)
-
-        config.add_level.assert_called_once_with("team", "https://github.com/team/repo", None)
-
-    def test_processes_remove_command(self):
-        """Test processing of remove command."""
-        args = Mock()
-        args.config_command = "remove"
-        args.name = "team"
-
-        config = Mock(spec=Config)
-
-        ConfigCommands.process_cli_command(args, config)
-
-        config.remove_level.assert_called_once_with("team")
-
-    def test_processes_update_command(self):
-        """Test processing of update command."""
-        args = Mock()
-        args.config_command = "update"
-        args.name = "team"
-        args.url = "https://github.com/team/new-repo"
-        args.rename = "new-team"
-
-        config = Mock(spec=Config)
-
-        ConfigCommands.process_cli_command(args, config)
-
-        config.update_level.assert_called_once_with("team", "https://github.com/team/new-repo", "new-team")
-
-    def test_processes_move_command_with_position(self):
-        """Test processing of move command with position."""
-        args = Mock()
-        args.config_command = "move"
-        args.name = "team"
-        args.position = 2
-        args.up = False
-        args.down = False
-
-        config = Mock(spec=Config)
-
-        ConfigCommands.process_cli_command(args, config)
-
-        config.move_level.assert_called_once_with("team", 2, None)
-
-    def test_processes_move_command_with_up(self):
-        """Test processing of move command with up direction."""
-        args = Mock()
-        args.config_command = "move"
-        args.name = "team"
-        args.position = None
-        args.up = True
-        args.down = False
-
-        config = Mock(spec=Config)
-
-        ConfigCommands.process_cli_command(args, config)
-
-        config.move_level.assert_called_once_with("team", None, "up")
-
-    def test_processes_move_command_with_down(self):
-        """Test processing of move command with down direction."""
-        args = Mock()
-        args.config_command = "move"
-        args.name = "team"
-        args.position = None
-        args.up = False
-        args.down = True
-
-        config = Mock(spec=Config)
-
-        ConfigCommands.process_cli_command(args, config)
-
-        config.move_level.assert_called_once_with("team", None, "down")
+        mock_display.assert_called_once_with(config)
 
     @patch("agent_manager.cli_extensions.config_commands.ConfigCommands.validate_all")
-    def test_processes_validate_command(self, mock_validate):
-        """Test processing of validate command."""
-        args = Mock()
-        args.config_command = "validate"
-
+    def test_validate(self, mock_validate):
+        args = Mock(config_command="validate")
         config = Mock(spec=Config)
-
         ConfigCommands.process_cli_command(args, config)
-
         mock_validate.assert_called_once_with(config)
 
-    @patch("agent_manager.cli_extensions.config_commands.ConfigCommands.export_config")
-    def test_processes_export_command(self, mock_export):
-        """Test processing of export command."""
-        args = Mock()
-        args.config_command = "export"
-        args.file = "output.yaml"
-
+    @patch("agent_manager.cli_extensions.config_commands.ConfigCommands.template")
+    def test_template(self, mock_template):
+        args = Mock(config_command="template")
         config = Mock(spec=Config)
-
         ConfigCommands.process_cli_command(args, config)
+        mock_template.assert_called_once()
 
-        mock_export.assert_called_once_with(config, "output.yaml")
-
-    @patch("agent_manager.cli_extensions.config_commands.ConfigCommands.import_config")
-    def test_processes_import_command(self, mock_import):
-        """Test processing of import command."""
-        args = Mock()
-        args.config_command = "import"
-        args.file = "input.yaml"
-
+    @patch("agent_manager.cli_extensions.config_commands.ConfigCommands.defaults")
+    def test_defaults_show(self, mock_defaults):
+        args = Mock(config_command="defaults", repos=None, agents=None)
         config = Mock(spec=Config)
-
         ConfigCommands.process_cli_command(args, config)
+        mock_defaults.assert_called_once_with(config, None, None)
 
-        mock_import.assert_called_once_with(config, "input.yaml")
+    @patch("agent_manager.cli_extensions.config_commands.ConfigCommands.defaults")
+    def test_defaults_set(self, mock_defaults):
+        args = Mock(config_command="defaults", repos=["a", "b"], agents=["cursor"])
+        config = Mock(spec=Config)
+        ConfigCommands.process_cli_command(args, config)
+        mock_defaults.assert_called_once_with(config, ["a", "b"], ["cursor"])
 
     @patch("agent_manager.cli_extensions.config_commands.ConfigCommands.show_location")
-    def test_processes_where_command(self, mock_show):
-        """Test processing of where command."""
-        args = Mock()
-        args.config_command = "where"
-
+    def test_where(self, mock_show):
+        args = Mock(config_command="where")
         config = Mock(spec=Config)
-
         ConfigCommands.process_cli_command(args, config)
-
         mock_show.assert_called_once_with(config)
 
-    def test_processes_unknown_command(self):
-        """Test processing of unknown command."""
-        args = Mock()
-        args.config_command = "unknown"
-
+    def test_unknown_command(self):
+        args = Mock(config_command="unknown")
         config = Mock(spec=Config)
-
         with patch("agent_manager.cli_extensions.config_commands.message"), pytest.raises(SystemExit):
             ConfigCommands.process_cli_command(args, config)
 
-    def test_shows_help_when_no_subcommand(self):
-        """Test that no subcommand shows available commands instead of error."""
-        args = Mock()
-        args.config_command = None
-
+    def test_no_subcommand_shows_help(self):
+        args = Mock(config_command=None)
         config = Mock(spec=Config)
         messages = []
 
-        def capture_message(msg, *args, **kwargs):
+        def capture(msg, *a, **kw):
             messages.append(msg)
 
-        with patch("agent_manager.cli_extensions.config_commands.message", side_effect=capture_message):
-            # Should return without error, not raise SystemExit
+        with patch("agent_manager.cli_extensions.config_commands.message", side_effect=capture):
             ConfigCommands.process_cli_command(args, config)
 
-        # Should have printed available subcommands
-        assert any("Available" in str(m) or "subcommand" in str(m).lower() for m in messages)
+        assert any("Available" in str(m) for m in messages)
 
 
 class TestConfigCommandsDisplay:
-    """Test cases for display method."""
 
-    def test_display_shows_hierarchy(self, tmp_path):
-        """Test that display shows hierarchy configuration."""
+    def test_display_shows_repos_and_directories(self):
         config = Mock(spec=Config)
         config.exists.return_value = True
         config.read.return_value = {
-            "hierarchy": [
+            "repos": [
                 {"name": "org", "url": "https://github.com/org/repo", "repo_type": "git"},
-                {"name": "team", "url": "file:///tmp/team", "repo_type": "file"},
-            ]
+            ],
+            "default_hierarchy": ["org"],
+            "default_agents": ["cursor"],
+            "directories": {
+                "HOME": {"type": "local", "agents": ["cursor"], "hierarchy": ["org"]},
+            },
         }
 
         with patch("agent_manager.cli_extensions.config_commands.message"):
             ConfigCommands.display(config)
 
-        config.exists.assert_called_once()
-        config.read.assert_called_once()
-
     def test_display_errors_when_no_config(self):
-        """Test that display errors when config doesn't exist."""
         config = Mock(spec=Config)
         config.exists.return_value = False
 
         with patch("agent_manager.cli_extensions.config_commands.message"), pytest.raises(SystemExit):
             ConfigCommands.display(config)
 
-    @patch("agent_manager.cli_extensions.config_commands.create_repo")
-    def test_display_resolves_paths(self, mock_create, tmp_path):
-        """Test that display resolves file paths when requested."""
-        mock_repo = Mock()
-        mock_repo.get_display_url.return_value = "/resolved/path"
-        mock_create.return_value = mock_repo
-
-        config = Mock(spec=Config)
-        config.exists.return_value = True
-        config.repos_directory = tmp_path
-        config.read.return_value = {"hierarchy": [{"name": "team", "url": "file:///tmp/team", "repo_type": "file"}]}
-
-        with patch("agent_manager.cli_extensions.config_commands.message"):
-            ConfigCommands.display(config, resolve_paths=True)
-
-        mock_create.assert_called_once()
-
-
-class TestConfigCommandsValidateAll:
-    """Test cases for validate_all method."""
-
-    def test_validates_all_repositories(self, tmp_path):
-        """Test validation of all repositories."""
+    def test_display_handles_none_directory(self):
         config = Mock(spec=Config)
         config.exists.return_value = True
         config.read.return_value = {
-            "hierarchy": [
+            "repos": [],
+            "directories": {"HOME": None},
+        }
+
+        with patch("agent_manager.cli_extensions.config_commands.message"):
+            ConfigCommands.display(config)
+
+    def test_display_handles_no_directories(self):
+        config = Mock(spec=Config)
+        config.exists.return_value = True
+        config.read.return_value = {"repos": []}
+
+        with patch("agent_manager.cli_extensions.config_commands.message"):
+            ConfigCommands.display(config)
+
+
+class TestConfigCommandsValidateAll:
+
+    def test_validates_all_repos(self):
+        config = Mock(spec=Config)
+        config.exists.return_value = True
+        config.read.return_value = {
+            "repos": [
                 {"name": "org", "url": "https://github.com/org/repo", "repo_type": "git"},
                 {"name": "team", "url": "file:///tmp/team", "repo_type": "file"},
-            ]
+            ],
         }
         config.validate_repo_url.return_value = True
 
@@ -314,23 +159,18 @@ class TestConfigCommandsValidateAll:
 
         assert config.validate_repo_url.call_count == 2
 
-    def test_validates_all_reports_failures(self):
-        """Test that validate_all reports validation failures."""
+    def test_exits_on_failure(self):
         config = Mock(spec=Config)
         config.exists.return_value = True
         config.read.return_value = {
-            "hierarchy": [
-                {"name": "org", "url": "https://github.com/org/repo", "repo_type": "git"},
-                {"name": "bad", "url": "invalid://url", "repo_type": "unknown"},
-            ]
+            "repos": [{"name": "bad", "url": "bad", "repo_type": "x"}],
         }
-        config.validate_repo_url.side_effect = [True, False]
+        config.validate_repo_url.return_value = False
 
         with patch("agent_manager.cli_extensions.config_commands.message"), pytest.raises(SystemExit):
             ConfigCommands.validate_all(config)
 
-    def test_validates_all_errors_when_no_config(self):
-        """Test that validate_all errors when config doesn't exist."""
+    def test_errors_when_no_config(self):
         config = Mock(spec=Config)
         config.exists.return_value = False
 
@@ -338,229 +178,40 @@ class TestConfigCommandsValidateAll:
             ConfigCommands.validate_all(config)
 
 
-class TestConfigCommandsExportConfig:
-    """Test cases for export_config method."""
+class TestConfigCommandsTemplate:
 
-    def test_exports_to_file(self, tmp_path):
-        """Test exporting configuration to file."""
-        output_file = tmp_path / "export.yaml"
+    def test_prints_template(self, capsys):
+        ConfigCommands.template()
+        out = capsys.readouterr().out
+        assert "repos:" in out
+        assert "directories:" in out
 
+
+class TestConfigCommandsDefaults:
+
+    def test_shows_defaults(self):
         config = Mock(spec=Config)
-        config.exists.return_value = True
-        config.read.return_value = {
-            "hierarchy": [{"name": "org", "url": "https://github.com/org/repo", "repo_type": "git", "repo": Mock()}]
+        config.get_defaults.return_value = {
+            "default_hierarchy": ["org"],
+            "default_agents": ["cursor"],
         }
-
         with patch("agent_manager.cli_extensions.config_commands.message"):
-            ConfigCommands.export_config(config, str(output_file))
+            ConfigCommands.defaults(config)
 
-        assert output_file.exists()
-
-        # Verify exported content
-        with open(output_file) as f:
-            exported = yaml.safe_load(f)
-
-        assert "hierarchy" in exported
-        assert exported["hierarchy"][0]["name"] == "org"
-        assert "repo" not in exported["hierarchy"][0]  # Should be removed
-
-    def test_exports_to_stdout(self, capsys):
-        """Test exporting configuration to stdout."""
+    def test_sets_defaults(self):
         config = Mock(spec=Config)
-        config.exists.return_value = True
-        config.read.return_value = {
-            "hierarchy": [{"name": "org", "url": "https://github.com/org/repo", "repo_type": "git", "repo": Mock()}]
-        }
-
         with patch("agent_manager.cli_extensions.config_commands.message"):
-            ConfigCommands.export_config(config, None)
-
-        captured = capsys.readouterr()
-        assert "org" in captured.out
-        assert "hierarchy" in captured.out
-
-    def test_exports_with_mergers_section(self, tmp_path):
-        """Test that export includes mergers section if present."""
-        output_file = tmp_path / "export.yaml"
-
-        config = Mock(spec=Config)
-        config.exists.return_value = True
-        config.read.return_value = {
-            "hierarchy": [{"name": "org", "url": "url", "repo_type": "git", "repo": Mock()}],
-            "mergers": {"JsonMerger": {"indent": 2}},
-        }
-
-        with patch("agent_manager.cli_extensions.config_commands.message"):
-            ConfigCommands.export_config(config, str(output_file))
-
-        with open(output_file) as f:
-            exported = yaml.safe_load(f)
-
-        assert "mergers" in exported
-        assert exported["mergers"]["JsonMerger"]["indent"] == 2
-
-    def test_export_errors_when_no_config(self):
-        """Test that export errors when config doesn't exist."""
-        config = Mock(spec=Config)
-        config.exists.return_value = False
-
-        with patch("agent_manager.cli_extensions.config_commands.message"), pytest.raises(SystemExit):
-            ConfigCommands.export_config(config, "output.yaml")
-
-
-class TestConfigCommandsImportConfig:
-    """Test cases for import_config method."""
-
-    def test_imports_from_file(self, tmp_path):
-        """Test importing configuration from file."""
-        input_file = tmp_path / "import.yaml"
-        import_data = {"hierarchy": [{"name": "org", "url": "https://github.com/org/repo", "repo_type": "git"}]}
-
-        with open(input_file, "w") as f:
-            yaml.dump(import_data, f)
-
-        config = Mock(spec=Config)
-        config.exists.return_value = False
-        config.config_file = tmp_path / "config.yaml"
-
-        with patch("agent_manager.cli_extensions.config_commands.message"):
-            ConfigCommands.import_config(config, str(input_file))
-
-        config.write.assert_called_once()
-
-    def test_import_prompts_before_overwrite(self, tmp_path):
-        """Test that import prompts before overwriting existing config."""
-        input_file = tmp_path / "import.yaml"
-        import_data = {"hierarchy": [{"name": "org", "url": "url", "repo_type": "git"}]}
-
-        with open(input_file, "w") as f:
-            yaml.dump(import_data, f)
-
-        config = Mock(spec=Config)
-        config.exists.return_value = True
-        config.config_file = tmp_path / "config.yaml"
-
-        with (
-            patch("agent_manager.cli_extensions.config_commands.message"),
-            patch("builtins.input", return_value="no"),
-        ):
-            ConfigCommands.import_config(config, str(input_file))
-
-        # Should not write if user says no
-        config.write.assert_not_called()
-
-    def test_import_handles_missing_file(self):
-        """Test that import handles missing input file."""
-        config = Mock(spec=Config)
-
-        with patch("agent_manager.cli_extensions.config_commands.message"), pytest.raises(SystemExit):
-            ConfigCommands.import_config(config, "nonexistent.yaml")
-
-    def test_import_handles_invalid_yaml(self, tmp_path):
-        """Test that import handles invalid YAML."""
-        input_file = tmp_path / "invalid.yaml"
-        input_file.write_text("invalid: yaml: content:")
-
-        config = Mock(spec=Config)
-
-        with patch("agent_manager.cli_extensions.config_commands.message"), pytest.raises(SystemExit):
-            ConfigCommands.import_config(config, str(input_file))
-
-    def test_import_validates_structure(self, tmp_path):
-        """Test that import validates configuration structure."""
-        input_file = tmp_path / "invalid.yaml"
-        with open(input_file, "w") as f:
-            yaml.dump({"not_hierarchy": []}, f)
-
-        config = Mock(spec=Config)
-
-        with patch("agent_manager.cli_extensions.config_commands.message"), pytest.raises(SystemExit):
-            ConfigCommands.import_config(config, str(input_file))
+            ConfigCommands.defaults(config, repos=["a", "b"], agents=["c"])
+        config.set_defaults.assert_called_once_with(repos=["a", "b"], agents=["c"])
 
 
 class TestConfigCommandsShowLocation:
-    """Test cases for show_location method."""
 
-    def test_shows_configuration_locations(self, tmp_path):
-        """Test that show_location displays config file locations."""
+    def test_shows_paths(self, tmp_path):
         config = Mock(spec=Config)
-
-        # Mock the path attributes and their exists() methods
-        config.config_directory = Mock()
-        config.config_directory.__str__ = Mock(return_value=str(tmp_path / "config"))
-        config.config_directory.exists = Mock(return_value=False)
-
-        config.config_file = Mock()
-        config.config_file.__str__ = Mock(return_value=str(tmp_path / "config" / "config.yaml"))
-        config.config_file.exists = Mock(return_value=False)
-
-        config.repos_directory = Mock()
-        config.repos_directory.__str__ = Mock(return_value=str(tmp_path / "config" / "repos"))
-        config.repos_directory.exists = Mock(return_value=False)
-
-        with patch("agent_manager.cli_extensions.config_commands.message"):
-            ConfigCommands.show_location(config)
-
-        # Should not raise any errors
-
-    def test_shows_existence_status(self, tmp_path):
-        """Test that show_location shows existence status."""
-        config_dir = tmp_path / "config"
-        config_dir.mkdir()
-        config_file = config_dir / "config.yaml"
-        config_file.touch()
-
-        config = Mock(spec=Config)
-        config.config_directory = config_dir
-        config.config_file = config_file
-        config.repos_directory = config_dir / "repos"
-
-        with patch("agent_manager.cli_extensions.config_commands.message"):
-            ConfigCommands.show_location(config)
-
-
-class TestConfigCommandsEdgeCases:
-    """Test cases for edge cases and special scenarios."""
-
-    def test_display_handles_unicode_names(self):
-        """Test that display handles Unicode in hierarchy names."""
-        config = Mock(spec=Config)
-        config.exists.return_value = True
-        config.read.return_value = {"hierarchy": [{"name": "组织", "url": "https://example.com", "repo_type": "git"}]}
-
-        with patch("agent_manager.cli_extensions.config_commands.message"):
-            ConfigCommands.display(config)
-
-    def test_export_handles_write_error(self, tmp_path):
-        """Test that export handles write errors."""
-        output_file = tmp_path / "readonly"
-        output_file.mkdir()  # Make it a directory to cause error
-
-        config = Mock(spec=Config)
-        config.exists.return_value = True
-        config.read.return_value = {"hierarchy": [{"name": "org", "url": "url", "repo_type": "git", "repo": Mock()}]}
-
-        with patch("agent_manager.cli_extensions.config_commands.message"), pytest.raises(SystemExit):
-            ConfigCommands.export_config(config, str(output_file))
-
-    def test_import_accepts_yes_variations(self, tmp_path):
-        """Test that import accepts various yes responses."""
-        input_file = tmp_path / "import.yaml"
-        import_data = {"hierarchy": [{"name": "org", "url": "url", "repo_type": "git"}]}
-
-        with open(input_file, "w") as f:
-            yaml.dump(import_data, f)
-
-        config = Mock(spec=Config)
-        config.exists.return_value = True
+        config.config_directory = tmp_path
         config.config_file = tmp_path / "config.yaml"
+        config.repos_directory = tmp_path / "repos"
 
-        for yes_response in ["yes", "y", "YES", "Y"]:
-            with (
-                patch("agent_manager.cli_extensions.config_commands.message"),
-                patch("builtins.input", return_value=yes_response),
-            ):
-                ConfigCommands.import_config(config, str(input_file))
-
-            config.write.assert_called()
-            config.write.reset_mock()
+        with patch("agent_manager.cli_extensions.config_commands.message"):
+            ConfigCommands.show_location(config)

--- a/tests/cli_extensions/test_merger_commands.py
+++ b/tests/cli_extensions/test_merger_commands.py
@@ -243,9 +243,9 @@ class TestMergerCommandsConfigureCommand:
         # Ensure config directory exists
         mock_config.ensure_directories()
 
-        # Create a config file with a valid hierarchy (no repo objects - they can't be serialized)
+        # Create a config file with valid repos (no repo objects - they can't be serialized)
         config_data = {
-            "hierarchy": [{"name": "test", "url": "https://github.com/test/repo", "repo_type": "git"}],
+            "repos": [{"name": "test", "url": "https://github.com/test/repo", "repo_type": "git"}],
             "mergers": {"JsonMerger": {"indent": 4, "sort_keys": True}},
         }
 
@@ -273,7 +273,7 @@ class TestMergerCommandsConfigureCommand:
         mock_config.ensure_directories()
 
         # Create a minimal config without mergers section but with valid hierarchy
-        config_data = {"hierarchy": [{"name": "test", "url": "https://github.com/test/repo", "repo_type": "git"}]}
+        config_data = {"repos": [{"name": "test", "url": "https://github.com/test/repo", "repo_type": "git"}]}
 
         # Write the config file directly as YAML to avoid serialization issues
         import yaml
@@ -301,7 +301,7 @@ class TestMergerCommandsConfigureCommand:
         # Ensure config directory exists
         mock_config.ensure_directories()
 
-        config_data = {"hierarchy": [{"name": "test", "url": "https://github.com/test/repo", "repo_type": "git"}]}
+        config_data = {"repos": [{"name": "test", "url": "https://github.com/test/repo", "repo_type": "git"}]}
 
         # Write the config file directly as YAML to avoid serialization issues
         import yaml
@@ -329,7 +329,9 @@ class TestMergerCommandsConfigureCommand:
         # Ensure config directory exists
         mock_config.ensure_directories()
 
-        config_data = {"hierarchy": [{"name": "test", "url": "https://github.com/test/repo", "repo_type": "git"}]}
+        config_data = {
+            "repos": [{"name": "test", "url": "https://github.com/test/repo", "repo_type": "git"}],
+        }
         mock_config.write(config_data)
 
         with patch("agent_manager.cli_extensions.merger_commands.message"), pytest.raises(SystemExit):
@@ -339,7 +341,9 @@ class TestMergerCommandsConfigureCommand:
         """Test that int values below minimum are clamped."""
         mock_config.ensure_directories()
 
-        config_data = {"hierarchy": [{"name": "test", "url": "https://github.com/test/repo", "repo_type": "git"}]}
+        config_data = {
+            "repos": [{"name": "test", "url": "https://github.com/test/repo", "repo_type": "git"}],
+        }
         import yaml
 
         with open(mock_config.config_file, "w") as f:
@@ -366,7 +370,7 @@ class TestMergerCommandsConfigureCommand:
         """Test that int values above maximum are clamped."""
         mock_config.ensure_directories()
 
-        config_data = {"hierarchy": [{"name": "test", "url": "https://github.com/test/repo", "repo_type": "git"}]}
+        config_data = {"repos": [{"name": "test", "url": "https://github.com/test/repo", "repo_type": "git"}]}
         import yaml
 
         with open(mock_config.config_file, "w") as f:
@@ -393,7 +397,7 @@ class TestMergerCommandsConfigureCommand:
         """Test that invalid int input is handled gracefully."""
         mock_config.ensure_directories()
 
-        config_data = {"hierarchy": [{"name": "test", "url": "https://github.com/test/repo", "repo_type": "git"}]}
+        config_data = {"repos": [{"name": "test", "url": "https://github.com/test/repo", "repo_type": "git"}]}
         import yaml
 
         with open(mock_config.config_file, "w") as f:
@@ -416,7 +420,7 @@ class TestMergerCommandsConfigureCommand:
         """Test that various 'yes' inputs are recognized as True."""
         mock_config.ensure_directories()
 
-        config_data = {"hierarchy": [{"name": "test", "url": "https://github.com/test/repo", "repo_type": "git"}]}
+        config_data = {"repos": [{"name": "test", "url": "https://github.com/test/repo", "repo_type": "git"}]}
         import yaml
 
         with open(mock_config.config_file, "w") as f:
@@ -445,7 +449,7 @@ class TestMergerCommandsConfigureCommand:
         """Test that non-yes inputs are recognized as False."""
         mock_config.ensure_directories()
 
-        config_data = {"hierarchy": [{"name": "test", "url": "https://github.com/test/repo", "repo_type": "git"}]}
+        config_data = {"repos": [{"name": "test", "url": "https://github.com/test/repo", "repo_type": "git"}]}
         import yaml
 
         with open(mock_config.config_file, "w") as f:
@@ -471,7 +475,7 @@ class TestMergerCommandsConfigureCommand:
         """Test that valid string choice is accepted."""
         mock_config.ensure_directories()
 
-        config_data = {"hierarchy": [{"name": "test", "url": "https://github.com/test/repo", "repo_type": "git"}]}
+        config_data = {"repos": [{"name": "test", "url": "https://github.com/test/repo", "repo_type": "git"}]}
         import yaml
 
         with open(mock_config.config_file, "w") as f:
@@ -497,7 +501,7 @@ class TestMergerCommandsConfigureCommand:
         """Test that invalid string choice shows warning."""
         mock_config.ensure_directories()
 
-        config_data = {"hierarchy": [{"name": "test", "url": "https://github.com/test/repo", "repo_type": "git"}]}
+        config_data = {"repos": [{"name": "test", "url": "https://github.com/test/repo", "repo_type": "git"}]}
         import yaml
 
         with open(mock_config.config_file, "w") as f:

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1,4 +1,4 @@
-"""Tests for config/config.py - Configuration management."""
+"""Tests for config/config.py - V2 Configuration management."""
 
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -9,100 +9,91 @@ import yaml
 from agent_manager.config.config import Config, ConfigError
 
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _minimal_config(**overrides):
+    """Return a minimal valid V2 config dict, with optional overrides."""
+    base = {
+        "repos": [
+            {"name": "org", "url": "https://github.com/org/repo", "repo_type": "git"},
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_config(config_obj: Config, data: dict) -> None:
+    """Write raw YAML data to the config file without validation."""
+    config_obj.config_directory.mkdir(parents=True, exist_ok=True)
+    with open(config_obj.config_file, "w") as f:
+        yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+
+
+# ===========================================================================
+# ConfigError
+# ===========================================================================
 class TestConfigError:
     """Test cases for ConfigError exception."""
 
     def test_single_error_message(self):
-        """Test ConfigError with single error message."""
         error = ConfigError("Single error")
-
         assert len(error.errors) == 1
         assert str(error) == "Single error"
 
     def test_multiple_error_messages(self):
-        """Test ConfigError with multiple error messages."""
         errors = ["Error 1", "Error 2", "Error 3"]
         error = ConfigError(errors)
-
         assert len(error.errors) == 3
         assert "Configuration has 3 errors" in str(error)
-        assert "Error 1" in str(error)
-        assert "Error 2" in str(error)
 
     def test_format_errors_with_list(self):
-        """Test error formatting with list of errors."""
         error = ConfigError(["First", "Second"])
-
         formatted = str(error)
         assert "2 errors" in formatted
         assert "  - First" in formatted
         assert "  - Second" in formatted
 
 
+# ===========================================================================
+# Config.__init__
+# ===========================================================================
 class TestConfigInitialization:
-    """Test cases for Config initialization."""
 
     def test_default_initialization(self):
-        """Test Config initialization with default directory."""
         config = Config()
-
         assert config.config_directory == Path.home() / ".agent-manager"
         assert config.config_file == Path.home() / ".agent-manager" / "config.yaml"
         assert config.repos_directory == Path.home() / ".agent-manager" / "repos"
 
     def test_custom_config_directory(self, tmp_path):
-        """Test Config initialization with custom directory."""
         custom_dir = tmp_path / "custom"
         config = Config(config_dir=custom_dir)
-
         assert config.config_directory == custom_dir
         assert config.config_file == custom_dir / "config.yaml"
-        assert config.repos_directory == custom_dir / "repos"
 
 
+# ===========================================================================
+# ensure_directories
+# ===========================================================================
 class TestConfigEnsureDirectories:
-    """Test cases for ensure_directories method."""
 
-    def test_creates_config_directory(self, tmp_path):
-        """Test that ensure_directories creates config directory."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-
+    def test_creates_config_and_repos_dirs(self, tmp_path):
+        config = Config(config_dir=tmp_path / "cfg")
         with patch("agent_manager.config.config.message"):
             config.ensure_directories()
+        assert config.config_directory.exists()
+        assert config.repos_directory.exists()
 
-        assert config_dir.exists()
-        assert config_dir.is_dir()
-
-    def test_creates_repos_directory(self, tmp_path):
-        """Test that ensure_directories creates repos directory."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-
+    def test_idempotent(self, tmp_path):
+        config = Config(config_dir=tmp_path / "cfg")
         with patch("agent_manager.config.config.message"):
             config.ensure_directories()
-
-        repos_dir = config_dir / "repos"
-        assert repos_dir.exists()
-        assert repos_dir.is_dir()
-
-    def test_idempotent_creation(self, tmp_path):
-        """Test that ensure_directories is idempotent."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-
-        with patch("agent_manager.config.config.message"):
             config.ensure_directories()
-            config.ensure_directories()  # Call again
-
-        # Should not raise error
-        assert config_dir.exists()
+        assert config.config_directory.exists()
 
     def test_handles_permission_error(self, tmp_path):
-        """Test that ensure_directories handles permission errors."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-
+        config = Config(config_dir=tmp_path / "cfg")
         with (
             patch("pathlib.Path.mkdir", side_effect=PermissionError),
             patch("agent_manager.config.config.message"),
@@ -111,10 +102,7 @@ class TestConfigEnsureDirectories:
             config.ensure_directories()
 
     def test_handles_os_error(self, tmp_path):
-        """Test that ensure_directories handles OS errors."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-
+        config = Config(config_dir=tmp_path / "cfg")
         with (
             patch("pathlib.Path.mkdir", side_effect=OSError("Disk full")),
             patch("agent_manager.config.config.message"),
@@ -123,941 +111,576 @@ class TestConfigEnsureDirectories:
             config.ensure_directories()
 
     def test_handles_generic_exception(self, tmp_path):
-        """Test that ensure_directories handles unexpected exceptions."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-
+        config = Config(config_dir=tmp_path / "cfg")
         with (
-            patch("pathlib.Path.mkdir", side_effect=RuntimeError("Unexpected error")),
+            patch("pathlib.Path.mkdir", side_effect=RuntimeError("oops")),
             patch("agent_manager.config.config.message"),
             pytest.raises(SystemExit),
         ):
             config.ensure_directories()
 
 
-class TestConfigValidateRepoUrl:
-    """Test cases for validate_repo_url static method."""
-
-    @patch("agent_manager.config.config.discover_repo_types")
-    def test_validates_git_url(self, mock_discover):
-        """Test validation of git URL."""
-        from agent_manager.plugins.repos.git_repo import GitRepo
-
-        mock_git_repo = Mock(spec=GitRepo)
-        mock_git_repo.REPO_TYPE = "git"
-        mock_git_repo.can_handle_url.return_value = True
-        mock_git_repo.validate_url.return_value = True
-
-        mock_discover.return_value = [mock_git_repo]
-
-        with patch("agent_manager.config.config.message"):
-            result = Config.validate_repo_url("https://github.com/user/repo")
-
-        assert result is True
-
-    @patch("agent_manager.config.config.discover_repo_types")
-    def test_validates_file_url(self, mock_discover):
-        """Test validation of file URL."""
-        from agent_manager.plugins.repos.local_repo import LocalRepo
-
-        mock_local_repo = Mock(spec=LocalRepo)
-        mock_local_repo.REPO_TYPE = "file"
-        mock_local_repo.can_handle_url.return_value = True
-        mock_local_repo.validate_url.return_value = True
-
-        mock_discover.return_value = [mock_local_repo]
-
-        with patch("agent_manager.config.config.message"):
-            result = Config.validate_repo_url("file:///tmp/repo")
-
-        assert result is True
-
-    @patch("agent_manager.config.config.Config.detect_repo_types")
-    def test_rejects_invalid_url(self, mock_detect):
-        """Test rejection of invalid URL."""
-        mock_detect.return_value = []
-
-        with patch("agent_manager.config.config.message"):
-            result = Config.validate_repo_url("invalid://url")
-
-        assert result is False
-
-
-class TestConfigValidateRepoUrlEdgeCases:
-    """Test edge cases for validate_repo_url."""
-
-    def test_validate_url_with_missing_repo_class(self):
-        """Test validate_url when repo class is not found after detection."""
-        url = "https://github.com/test/repo"
-
-        # Mock detect_repo_types to return a type, but discover_repo_types to return empty
-        with (
-            patch("agent_manager.config.config.Config.detect_repo_types", return_value=["nonexistent"]),
-            patch("agent_manager.config.config.discover_repo_types", return_value=[]),
-            patch("agent_manager.config.config.message"),
-        ):
-            result = Config.validate_repo_url(url)
-
-            # Should return False and log internal error
-            assert result is False
-
-
-class TestConfigDetectRepoTypes:
-    """Test cases for detect_repo_types static method."""
-
-    @patch("agent_manager.config.config.discover_repo_types")
-    def test_detects_single_type(self, mock_discover):
-        """Test detection of single matching repo type."""
-        mock_repo = Mock()
-        mock_repo.REPO_TYPE = "git"
-        mock_repo.can_handle_url.return_value = True
-
-        mock_discover.return_value = [mock_repo]
-
-        types = Config.detect_repo_types("https://github.com/user/repo")
-
-        assert types == ["git"]
-
-    @patch("agent_manager.config.config.discover_repo_types")
-    def test_detects_multiple_types(self, mock_discover):
-        """Test detection of multiple matching repo types."""
-        mock_repo1 = Mock()
-        mock_repo1.REPO_TYPE = "type1"
-        mock_repo1.can_handle_url.return_value = True
-
-        mock_repo2 = Mock()
-        mock_repo2.REPO_TYPE = "type2"
-        mock_repo2.can_handle_url.return_value = True
-
-        mock_discover.return_value = [mock_repo1, mock_repo2]
-
-        types = Config.detect_repo_types("https://example.com")
-
-        assert "type1" in types
-        assert "type2" in types
-
-    @patch("agent_manager.config.config.discover_repo_types")
-    def test_detects_no_types(self, mock_discover):
-        """Test detection when no types match."""
-        mock_repo = Mock()
-        mock_repo.can_handle_url.return_value = False
-
-        mock_discover.return_value = [mock_repo]
-
-        types = Config.detect_repo_types("invalid://url")
-
-        assert types == []
-
-
-class TestConfigPromptForRepoType:
-    """Test cases for prompt_for_repo_type static method."""
-
-    @patch("builtins.input", return_value="1")
-    def test_prompts_and_returns_selection(self, mock_input):
-        """Test that prompt returns selected repo type."""
-        url = "https://example.com"
-        available = ["git", "file"]
-
-        with patch("agent_manager.config.config.message"):
-            selected = Config.prompt_for_repo_type(url, available)
-
-        assert selected == "git"
-
-    @patch("builtins.input", return_value="2")
-    def test_prompts_returns_second_option(self, mock_input):
-        """Test selection of second option."""
-        available = ["type1", "type2", "type3"]
-
-        with patch("agent_manager.config.config.message"):
-            selected = Config.prompt_for_repo_type("url", available)
-
-        assert selected == "type2"
-
-    @patch("builtins.input", side_effect=["invalid", "0", "5", "2"])
-    def test_prompts_retries_on_invalid_input(self, mock_input):
-        """Test that prompt retries on invalid input."""
-        available = ["type1", "type2"]
-
-        with patch("agent_manager.config.config.message"):
-            selected = Config.prompt_for_repo_type("url", available)
-
-        # Should eventually select type2
-        assert selected == "type2"
-        assert mock_input.call_count == 4
-
-
-class TestConfigValidate:
-    """Test cases for validate static method."""
-
-    def test_validates_valid_config(self):
-        """Test validation of valid configuration."""
-        config = {
-            "hierarchy": [
-                {"name": "org", "url": "https://github.com/org/repo", "repo_type": "git"},
-                {"name": "team", "url": "file:///tmp/team", "repo_type": "file"},
-            ]
-        }
-
-        # Should not raise exception
-        Config.validate(config)
-
-    def test_rejects_missing_hierarchy(self):
-        """Test rejection of config without hierarchy key."""
-        config = {}
-
-        with pytest.raises(ConfigError) as exc_info:
-            Config.validate(config)
-
-        assert "must contain 'hierarchy' key" in str(exc_info.value)
-
-    def test_rejects_non_list_hierarchy(self):
-        """Test rejection of hierarchy that's not a list."""
-        config = {"hierarchy": "not a list"}
-
-        with pytest.raises(ConfigError) as exc_info:
-            Config.validate(config)
-
-        assert "'hierarchy' must be a list" in str(exc_info.value)
-
-    def test_rejects_empty_hierarchy(self):
-        """Test rejection of empty hierarchy."""
-        config = {"hierarchy": []}
-
-        with pytest.raises(ConfigError) as exc_info:
-            Config.validate(config)
-
-        assert "'hierarchy' cannot be empty" in str(exc_info.value)
-
-    def test_rejects_non_dict_entry(self):
-        """Test rejection of non-dictionary hierarchy entry."""
-        config = {"hierarchy": ["not a dict"]}
-
-        with pytest.raises(ConfigError) as exc_info:
-            Config.validate(config)
-
-        assert "must be a dictionary" in str(exc_info.value)
-
-    def test_rejects_missing_required_keys(self):
-        """Test rejection of entry missing required keys."""
-        config = {"hierarchy": [{"name": "org"}]}  # Missing url and repo_type
-
-        with pytest.raises(ConfigError) as exc_info:
-            Config.validate(config)
-
-        error_str = str(exc_info.value)
-        assert "missing required keys" in error_str
-        assert "url" in error_str
-        assert "repo_type" in error_str
-
-    def test_rejects_non_string_name(self):
-        """Test rejection of non-string name field."""
-        config = {"hierarchy": [{"name": 123, "url": "url", "repo_type": "git"}]}
-
-        with pytest.raises(ConfigError) as exc_info:
-            Config.validate(config)
-
-        assert "'name' must be a string" in str(exc_info.value)
-
-    def test_rejects_empty_name(self):
-        """Test rejection of empty name field."""
-        config = {"hierarchy": [{"name": "", "url": "url", "repo_type": "git"}]}
-
-        with pytest.raises(ConfigError) as exc_info:
-            Config.validate(config)
-
-        assert "'name' cannot be empty" in str(exc_info.value)
-
-    def test_rejects_non_string_url(self):
-        """Test rejection of non-string url field."""
-        config = {"hierarchy": [{"name": "org", "url": 456, "repo_type": "git"}]}
-
-        with pytest.raises(ConfigError) as exc_info:
-            Config.validate(config)
-
-        assert "'url' must be a string" in str(exc_info.value)
-
-    def test_rejects_empty_url(self):
-        """Test rejection of empty url field."""
-        config = {"hierarchy": [{"name": "org", "url": "", "repo_type": "git"}]}
-
-        with pytest.raises(ConfigError) as exc_info:
-            Config.validate(config)
-
-        assert "'url' cannot be empty" in str(exc_info.value)
-
-    def test_rejects_non_string_repo_type(self):
-        """Test rejection of non-string repo_type field."""
-        config = {"hierarchy": [{"name": "org", "url": "url", "repo_type": 789}]}
-
-        with pytest.raises(ConfigError) as exc_info:
-            Config.validate(config)
-
-        assert "'repo_type' must be a string" in str(exc_info.value)
-
-    def test_rejects_empty_repo_type(self):
-        """Test rejection of empty repo_type field."""
-        config = {"hierarchy": [{"name": "org", "url": "url", "repo_type": ""}]}
-
-        with pytest.raises(ConfigError) as exc_info:
-            Config.validate(config)
-
-        assert "'repo_type' cannot be empty" in str(exc_info.value)
+# ===========================================================================
+# validate – repos
+# ===========================================================================
+class TestValidateRepos:
+
+    def test_valid_minimal_config(self):
+        Config.validate(_minimal_config())
+
+    def test_missing_repos_key(self):
+        with pytest.raises(ConfigError, match="must contain 'repos' key"):
+            Config.validate({})
+
+    def test_repos_not_a_list(self):
+        with pytest.raises(ConfigError, match="'repos' must be a list"):
+            Config.validate({"repos": "bad"})
+
+    def test_repo_entry_not_dict(self):
+        with pytest.raises(ConfigError, match="must be a dictionary"):
+            Config.validate({"repos": ["bad"]})
+
+    def test_repo_missing_required_keys(self):
+        with pytest.raises(ConfigError, match="missing required keys"):
+            Config.validate({"repos": [{"name": "x"}]})
+
+    def test_repo_name_not_string(self):
+        with pytest.raises(ConfigError, match="'name' must be a string"):
+            Config.validate({"repos": [{"name": 123, "url": "u", "repo_type": "git"}]})
+
+    def test_repo_name_empty(self):
+        with pytest.raises(ConfigError, match="'name' cannot be empty"):
+            Config.validate({"repos": [{"name": "", "url": "u", "repo_type": "git"}]})
+
+    def test_repo_duplicate_name(self):
+        with pytest.raises(ConfigError, match="duplicate name"):
+            Config.validate({
+                "repos": [
+                    {"name": "dup", "url": "u1", "repo_type": "git"},
+                    {"name": "dup", "url": "u2", "repo_type": "git"},
+                ]
+            })
+
+    def test_repo_url_not_string(self):
+        with pytest.raises(ConfigError, match="'url' must be a string"):
+            Config.validate({"repos": [{"name": "x", "url": 123, "repo_type": "git"}]})
+
+    def test_repo_url_empty(self):
+        with pytest.raises(ConfigError, match="'url' cannot be empty"):
+            Config.validate({"repos": [{"name": "x", "url": "", "repo_type": "git"}]})
+
+    def test_repo_type_not_string(self):
+        with pytest.raises(ConfigError, match="'repo_type' must be a string"):
+            Config.validate({"repos": [{"name": "x", "url": "u", "repo_type": 9}]})
+
+    def test_repo_type_empty(self):
+        with pytest.raises(ConfigError, match="'repo_type' cannot be empty"):
+            Config.validate({"repos": [{"name": "x", "url": "u", "repo_type": ""}]})
 
     def test_collects_multiple_errors(self):
-        """Test that validation collects multiple errors."""
-        config = {
-            "hierarchy": [
-                {"name": "", "url": "", "repo_type": ""},  # 3 errors
-                {"name": 123, "url": 456, "repo_type": 789},  # 3 errors
-            ]
-        }
-
-        with pytest.raises(ConfigError) as exc_info:
-            Config.validate(config)
-
-        error_str = str(exc_info.value)
-        assert "6 errors" in error_str or "cannot be empty" in error_str
+        with pytest.raises(ConfigError) as exc:
+            Config.validate({
+                "repos": [
+                    {"name": "", "url": "", "repo_type": ""},
+                    {"name": 1, "url": 2, "repo_type": 3},
+                ]
+            })
+        assert len(exc.value.errors) >= 4
 
 
-class TestConfigWrite:
-    """Test cases for write method."""
+# ===========================================================================
+# validate – default_hierarchy
+# ===========================================================================
+class TestValidateDefaultHierarchy:
 
-    def test_writes_valid_config(self, tmp_path):
-        """Test writing valid configuration."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config_dir.mkdir()
+    def test_valid_default_hierarchy(self):
+        Config.validate(_minimal_config(default_hierarchy=["org"]))
 
-        config_data = {"hierarchy": [{"name": "org", "url": "https://github.com/org/repo", "repo_type": "git"}]}
+    def test_default_hierarchy_not_list(self):
+        with pytest.raises(ConfigError, match="'default_hierarchy' must be a list"):
+            Config.validate(_minimal_config(default_hierarchy="bad"))
 
+    def test_default_hierarchy_entry_not_string(self):
+        with pytest.raises(ConfigError, match="default_hierarchy entry 0 must be a string"):
+            Config.validate(_minimal_config(default_hierarchy=[123]))
+
+    def test_default_hierarchy_references_unknown_repo(self):
+        with pytest.raises(ConfigError, match="does not match any repo name"):
+            Config.validate(_minimal_config(default_hierarchy=["nonexistent"]))
+
+
+# ===========================================================================
+# validate – default_agents
+# ===========================================================================
+class TestValidateDefaultAgents:
+
+    def test_valid_default_agents(self):
+        Config.validate(_minimal_config(default_agents=["cursor", "claude"]))
+
+    def test_default_agents_not_list(self):
+        with pytest.raises(ConfigError, match="'default_agents' must be a list"):
+            Config.validate(_minimal_config(default_agents="bad"))
+
+    def test_default_agents_entry_not_string(self):
+        with pytest.raises(ConfigError, match="default_agents entry 0 must be a string"):
+            Config.validate(_minimal_config(default_agents=[99]))
+
+    def test_default_agents_entry_empty(self):
+        with pytest.raises(ConfigError, match="default_agents entry 0 cannot be empty"):
+            Config.validate(_minimal_config(default_agents=[""]))
+
+
+# ===========================================================================
+# validate – directories
+# ===========================================================================
+class TestValidateDirectories:
+
+    def test_valid_directories(self):
+        Config.validate(_minimal_config(
+            default_hierarchy=["org"],
+            directories={"HOME": {"type": "local", "agents": ["cursor"], "hierarchy": ["org"]}},
+        ))
+
+    def test_directories_not_dict(self):
+        with pytest.raises(ConfigError, match="'directories' must be a dictionary"):
+            Config.validate(_minimal_config(directories="bad"))
+
+    def test_directory_config_not_dict(self):
+        with pytest.raises(ConfigError, match="config must be a dictionary"):
+            Config.validate(_minimal_config(directories={"HOME": "bad"}))
+
+    def test_directory_none_value_accepted(self):
+        """A directory with None (bare key in YAML) is valid."""
+        Config.validate(_minimal_config(
+            default_hierarchy=["org"],
+            directories={"HOME": None},
+        ))
+
+    def test_directory_type_not_string(self):
+        with pytest.raises(ConfigError, match="'type' must be a string"):
+            Config.validate(_minimal_config(directories={"HOME": {"type": 123}}))
+
+    def test_directory_type_empty(self):
+        with pytest.raises(ConfigError, match="'type' cannot be empty"):
+            Config.validate(_minimal_config(directories={"HOME": {"type": ""}}))
+
+    def test_directory_agents_not_list(self):
+        with pytest.raises(ConfigError, match="'agents' must be a list"):
+            Config.validate(_minimal_config(directories={"HOME": {"agents": "bad"}}))
+
+    def test_directory_agents_entry_not_string(self):
+        with pytest.raises(ConfigError, match="agents entry 0 must be a string"):
+            Config.validate(_minimal_config(directories={"HOME": {"agents": [42]}}))
+
+    def test_directory_hierarchy_not_list(self):
+        with pytest.raises(ConfigError, match="'hierarchy' must be a list"):
+            Config.validate(_minimal_config(directories={"HOME": {"hierarchy": "bad"}}))
+
+    def test_directory_hierarchy_entry_not_string(self):
+        with pytest.raises(ConfigError, match="hierarchy entry 0 must be a string"):
+            Config.validate(_minimal_config(directories={"HOME": {"hierarchy": [42]}}))
+
+    def test_directory_hierarchy_references_unknown_repo(self):
+        with pytest.raises(ConfigError, match="does not match any repo name"):
+            Config.validate(_minimal_config(directories={"HOME": {"hierarchy": ["ghost"]}}))
+
+    def test_warns_when_no_hierarchy_and_no_default(self):
+        """Should warn when directory omits hierarchy and no default_hierarchy."""
+        warnings = Config.validate(_minimal_config(directories={"HOME": {}}))
+        assert any("no repos will be merged" in w for w in warnings)
+
+    def test_no_warning_when_directory_has_hierarchy(self):
+        warnings = Config.validate(_minimal_config(directories={"HOME": {"hierarchy": ["org"]}}))
+        assert len(warnings) == 0
+
+    def test_no_warning_when_default_hierarchy_set(self):
+        warnings = Config.validate(_minimal_config(
+            default_hierarchy=["org"],
+            directories={"HOME": {}},
+        ))
+        assert len(warnings) == 0
+
+
+# ===========================================================================
+# validate – extra fields
+# ===========================================================================
+class TestValidateExtraFields:
+
+    def test_allows_additional_top_level_keys(self):
+        cfg = _minimal_config()
+        cfg["mergers"] = {"JsonMerger": {"indent": 2}}
+        Config.validate(cfg)
+
+    def test_allows_extra_keys_in_repo_entry(self):
+        cfg = _minimal_config()
+        cfg["repos"][0]["extra"] = "val"
+        Config.validate(cfg)
+
+
+# ===========================================================================
+# write / read round-trip
+# ===========================================================================
+class TestConfigWriteRead:
+
+    def test_write_and_read_minimal(self, tmp_path):
+        config = Config(config_dir=tmp_path / "cfg")
+        config.config_directory.mkdir(parents=True)
+
+        data = _minimal_config()
         with patch("agent_manager.config.config.message"):
-            config.write(config_data)
+            config.write(data)
 
         assert config.config_file.exists()
 
-        # Verify contents
-        with open(config.config_file) as f:
-            written = yaml.safe_load(f)
-
-        assert written["hierarchy"][0]["name"] == "org"
-
-    def test_write_rejects_invalid_config(self, tmp_path):
-        """Test that write rejects invalid configuration."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config_dir.mkdir()
-
-        invalid_config = {"hierarchy": []}  # Empty hierarchy
-
-        with pytest.raises(SystemExit):
-            config.write(invalid_config)
-
-    def test_write_handles_os_error(self, tmp_path):
-        """Test that write handles file system errors."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        # Don't create directory to cause error
-
-        config_data = {"hierarchy": [{"name": "org", "url": "https://github.com/org/repo", "repo_type": "git"}]}
-
-        with pytest.raises(SystemExit):
-            config.write(config_data)
-
-    def test_write_handles_generic_exception(self, tmp_path):
-        """Test that write handles unexpected exceptions."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config_dir.mkdir()
-
-        config_data = {"hierarchy": [{"name": "org", "url": "https://github.com/org/repo", "repo_type": "git"}]}
-
-        # Simulate unexpected exception during YAML dump
-        with patch("yaml.dump", side_effect=RuntimeError("Unexpected error")), pytest.raises(SystemExit):
-            config.write(config_data)
-
-
-class TestConfigRead:
-    """Test cases for read method."""
-
-    def test_reads_valid_config(self, tmp_path):
-        """Test reading valid configuration file."""
-        config_dir = tmp_path / "config"
-        config_dir.mkdir()
-
-        config_file = config_dir / "config.yaml"
-        config_data = {"hierarchy": [{"name": "org", "url": "https://github.com/org/repo", "repo_type": "git"}]}
-
-        with open(config_file, "w") as f:
-            yaml.dump(config_data, f)
-
-        config = Config(config_dir=config_dir)
-
         with (
             patch("agent_manager.config.config.message"),
-            patch("agent_manager.config.config.create_repo") as mock_create,
+            patch("agent_manager.config.config.create_repo", return_value=Mock()),
         ):
-            mock_create.return_value = Mock()
             loaded = config.read()
 
-        assert loaded["hierarchy"][0]["name"] == "org"
-        assert "repo" in loaded["hierarchy"][0]
+        assert loaded["repos"][0]["name"] == "org"
+
+    def test_write_full_config(self, tmp_path):
+        config = Config(config_dir=tmp_path / "cfg")
+        config.config_directory.mkdir(parents=True)
+
+        data = _minimal_config(
+            default_hierarchy=["org"],
+            default_agents=["cursor"],
+            directories={"HOME": {"type": "local", "agents": ["cursor"], "hierarchy": ["org"]}},
+        )
+
+        with patch("agent_manager.config.config.message"):
+            config.write(data)
+
+        with open(config.config_file) as f:
+            raw = yaml.safe_load(f)
+
+        assert raw["default_hierarchy"] == ["org"]
+        assert raw["default_agents"] == ["cursor"]
+        assert raw["directories"]["HOME"]["type"] == "local"
+
+    def test_write_rejects_invalid_config(self, tmp_path):
+        config = Config(config_dir=tmp_path / "cfg")
+        config.config_directory.mkdir(parents=True)
+
+        with pytest.raises(SystemExit):
+            config.write({})  # Missing repos key entirely
+
+    def test_write_handles_os_error(self, tmp_path):
+        config = Config(config_dir=tmp_path / "nonexistent")
+        with pytest.raises(SystemExit):
+            config.write(_minimal_config())
 
     def test_read_handles_missing_file(self, tmp_path):
-        """Test that read handles missing configuration file."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-
+        config = Config(config_dir=tmp_path / "cfg")
         with patch("agent_manager.config.config.message"), pytest.raises(SystemExit):
             config.read()
 
     def test_read_handles_empty_file(self, tmp_path):
-        """Test that read handles empty configuration file."""
-        config_dir = tmp_path / "config"
-        config_dir.mkdir()
-
-        config_file = config_dir / "config.yaml"
-        config_file.touch()  # Create empty file
-
-        config = Config(config_dir=config_dir)
-
+        config = Config(config_dir=tmp_path / "cfg")
+        config.config_directory.mkdir(parents=True)
+        config.config_file.touch()
         with patch("agent_manager.config.config.message"), pytest.raises(SystemExit):
             config.read()
 
-    def test_read_handles_invalid_config(self, tmp_path):
-        """Test that read handles invalid configuration."""
-        config_dir = tmp_path / "config"
-        config_dir.mkdir()
-
-        config_file = config_dir / "config.yaml"
-        with open(config_file, "w") as f:
-            yaml.dump({"hierarchy": []}, f)  # Invalid (empty)
-
-        config = Config(config_dir=config_dir)
-
+    def test_read_handles_invalid_yaml(self, tmp_path):
+        config = Config(config_dir=tmp_path / "cfg")
+        config.config_directory.mkdir(parents=True)
+        config.config_file.write_text("invalid: yaml: content: [")
         with patch("agent_manager.config.config.message"), pytest.raises(SystemExit):
             config.read()
 
 
+# ===========================================================================
+# exists
+# ===========================================================================
 class TestConfigExists:
-    """Test cases for exists method."""
 
-    def test_exists_returns_true_when_file_exists(self, tmp_path):
-        """Test that exists returns True when config file exists."""
-        config_dir = tmp_path / "config"
-        config_dir.mkdir()
-
-        config_file = config_dir / "config.yaml"
-        config_file.touch()
-
-        config = Config(config_dir=config_dir)
-
+    def test_returns_true_when_exists(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        (tmp_path / "config.yaml").touch()
         assert config.exists() is True
 
-    def test_exists_returns_false_when_file_missing(self, tmp_path):
-        """Test that exists returns False when config file doesn't exist."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-
+    def test_returns_false_when_missing(self, tmp_path):
+        config = Config(config_dir=tmp_path / "nonexistent")
         assert config.exists() is False
 
 
-class TestConfigInitialize:
-    """Test cases for initialize method."""
+# ===========================================================================
+# get_repo_names / get_directory_paths
+# ===========================================================================
+class TestConfigGetters:
 
-    def test_initialize_creates_config(self, tmp_path):
-        """Test that initialize creates configuration."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
+    def test_get_repo_names(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        _write_config(config, _minimal_config())
+        assert config.get_repo_names() == ["org"]
 
-        # Ensure directories exist
-        config.ensure_directories()
+    def test_get_repo_names_empty(self, tmp_path):
+        config = Config(config_dir=tmp_path / "x")
+        assert config.get_repo_names() == []
+
+    def test_get_directory_paths(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        _write_config(config, _minimal_config(directories={"HOME": None, "/x": {}}))
+        paths = config.get_directory_paths()
+        assert "HOME" in paths
+        assert "/x" in paths
+
+    def test_get_directory_paths_empty(self, tmp_path):
+        config = Config(config_dir=tmp_path / "x")
+        assert config.get_directory_paths() == []
+
+
+# ===========================================================================
+# add_repo
+# ===========================================================================
+class TestAddRepo:
+
+    def test_adds_repo(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        _write_config(config, _minimal_config())
 
         with (
             patch("agent_manager.config.config.message"),
-            patch("builtins.input", side_effect=['["org"]', "https://github.com/org/repo"]),
+            patch("agent_manager.config.config.create_repo", return_value=Mock()),
+            patch("agent_manager.config.config.Config.detect_repo_types", return_value=["file"]),
             patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
-            patch("agent_manager.config.config.Config.detect_repo_types", return_value=["git"]),
         ):
-            config.initialize()
+            config.add_repo("personal", "file:///tmp/personal")
 
-        assert config_dir.exists()
-        assert config.config_file.exists()
+        with open(config.config_file) as f:
+            raw = yaml.safe_load(f)
+        names = [r["name"] for r in raw["repos"]]
+        assert "personal" in names
 
-    def test_initialize_skips_if_exists(self, tmp_path):
-        """Test that initialize skips if config already exists."""
-        config_dir = tmp_path / "config"
-        config_dir.mkdir()
-
-        config_file = config_dir / "config.yaml"
-        config_file.touch()
-
-        config = Config(config_dir=config_dir)
-
-        with patch("agent_manager.config.config.message"):
-            config.initialize(skip_if_already_created=True)
-
-        # Should not prompt for input
-
-    def test_initialize_cancelled_on_overwrite_no(self, tmp_path):
-        """Test that initialize can be cancelled when overwriting."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
-        config.config_file.touch()  # Create existing file
+    def test_rejects_duplicate_name(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        _write_config(config, _minimal_config())
 
         with (
             patch("agent_manager.config.config.message"),
-            patch("builtins.input", return_value="no"),  # Say no to overwrite
-        ):
-            config.initialize(skip_if_already_created=False)
-
-        # File should still exist but not be modified (just touched, so empty)
-        assert config.config_file.exists()
-        assert config.config_file.stat().st_size == 0
-
-    def test_initialize_continues_on_overwrite_yes(self, tmp_path):
-        """Test that initialize continues when user confirms overwrite."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
-        config.config_file.touch()  # Create existing file
-
-        with (
-            patch("agent_manager.config.config.message"),
-            patch("builtins.input", side_effect=["yes", '["org"]', "https://github.com/org/repo"]),
+            patch("agent_manager.config.config.create_repo", return_value=Mock()),
             patch("agent_manager.config.config.Config.detect_repo_types", return_value=["git"]),
             patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
+            pytest.raises(SystemExit),
         ):
-            config.initialize(skip_if_already_created=False)
+            config.add_repo("org", "https://other.com")
 
-        # Config file should be updated with content
-        assert config.config_file.exists()
-        assert config.config_file.stat().st_size > 0
+    def test_rejects_when_no_config(self, tmp_path):
+        config = Config(config_dir=tmp_path / "x")
+        with patch("agent_manager.config.config.message"), pytest.raises(SystemExit):
+            config.add_repo("a", "u")
 
-    def test_initialize_hierarchy_not_a_list_retry(self, tmp_path):
-        """Test that initialize retries when hierarchy is not a list."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
+
+# ===========================================================================
+# remove_repo
+# ===========================================================================
+class TestRemoveRepo:
+
+    def test_removes_repo(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        data = _minimal_config()
+        data["repos"].append({"name": "extra", "url": "u", "repo_type": "git"})
+        _write_config(config, data)
 
         with (
             patch("agent_manager.config.config.message"),
-            patch(
-                "builtins.input",
-                side_effect=['{"key": "value"}', '["org"]', "https://github.com/org/repo"],
-            ),
-            patch("agent_manager.config.config.Config.detect_repo_types", return_value=["git"]),
-            patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
+            patch("agent_manager.config.config.create_repo", return_value=Mock()),
         ):
-            config.initialize()
+            config.remove_repo("extra")
 
-        assert config.config_file.exists()
+        with open(config.config_file) as f:
+            raw = yaml.safe_load(f)
+        names = [r["name"] for r in raw["repos"]]
+        assert "extra" not in names
 
-    def test_initialize_hierarchy_syntax_error_retry(self, tmp_path):
-        """Test that initialize retries on syntax error in hierarchy."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
+    def test_refuses_if_referenced_without_force(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        _write_config(config, _minimal_config(default_hierarchy=["org"]))
 
         with (
             patch("agent_manager.config.config.message"),
-            patch(
-                "builtins.input",
-                side_effect=["[invalid", '["org"]', "https://github.com/org/repo"],
-            ),
-            patch("agent_manager.config.config.Config.detect_repo_types", return_value=["git"]),
-            patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
+            patch("agent_manager.config.config.create_repo", return_value=Mock()),
+            pytest.raises(SystemExit),
         ):
-            config.initialize()
+            config.remove_repo("org", force=False)
 
-        assert config.config_file.exists()
-
-    def test_initialize_empty_url_retry(self, tmp_path):
-        """Test that initialize retries when URL is empty."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
+    def test_cascades_with_force(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        _write_config(config, _minimal_config(
+            default_hierarchy=["org"],
+            directories={"HOME": {"hierarchy": ["org"]}},
+        ))
 
         with (
             patch("agent_manager.config.config.message"),
-            patch(
-                "builtins.input",
-                side_effect=['["org"]', "", "https://github.com/org/repo"],
-            ),
-            patch("agent_manager.config.config.Config.detect_repo_types", return_value=["git"]),
-            patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
+            patch("agent_manager.config.config.create_repo", return_value=Mock()),
         ):
-            config.initialize()
+            config.remove_repo("org", force=True)
 
-        assert config.config_file.exists()
+        with open(config.config_file) as f:
+            raw = yaml.safe_load(f)
+        assert raw["repos"] == []
+        assert raw["default_hierarchy"] == []
 
-    def test_initialize_no_matching_repo_type_retry(self, tmp_path):
-        """Test that initialize retries when no repo type matches URL."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
+    def test_not_found(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        _write_config(config, _minimal_config())
+        with (
+            patch("agent_manager.config.config.message"),
+            patch("agent_manager.config.config.create_repo", return_value=Mock()),
+            pytest.raises(SystemExit),
+        ):
+            config.remove_repo("ghost")
+
+
+# ===========================================================================
+# add_directory / remove_directory
+# ===========================================================================
+class TestDirectoryManagement:
+
+    def test_add_directory(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        _write_config(config, _minimal_config(default_hierarchy=["org"]))
 
         with (
             patch("agent_manager.config.config.message"),
-            patch(
-                "builtins.input",
-                side_effect=['["org"]', "invalid://bad", "https://github.com/org/repo"],
-            ),
-            # First call returns empty, second returns git, then one more for validation
-            patch(
-                "agent_manager.config.config.Config.detect_repo_types",
-                side_effect=[[], ["git"]],
-            ),
-            patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
+            patch("agent_manager.config.config.create_repo", return_value=Mock()),
         ):
-            config.initialize()
+            config.add_directory("HOME", dir_type="local", agents=["cursor"])
 
-        assert config.config_file.exists()
+        with open(config.config_file) as f:
+            raw = yaml.safe_load(f)
+        assert "HOME" in raw["directories"]
+        assert raw["directories"]["HOME"]["type"] == "local"
 
-    def test_initialize_accepts_comma_separated_hierarchy(self, tmp_path):
-        """Test that initialize accepts comma-separated hierarchy levels."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
+    def test_add_directory_duplicate(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        _write_config(config, _minimal_config(directories={"HOME": None}))
+        with (
+            patch("agent_manager.config.config.message"),
+            patch("agent_manager.config.config.create_repo", return_value=Mock()),
+            pytest.raises(SystemExit),
+        ):
+            config.add_directory("HOME")
+
+    def test_remove_directory(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        _write_config(config, _minimal_config(
+            default_hierarchy=["org"],
+            directories={"HOME": None, "/x": None},
+        ))
 
         with (
             patch("agent_manager.config.config.message"),
-            patch(
-                "builtins.input",
-                side_effect=["org, team, personal", "url1", "url2", "url3"],
-            ),
-            patch("agent_manager.config.config.Config.detect_repo_types", return_value=["git"]),
-            patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
+            patch("agent_manager.config.config.create_repo", return_value=Mock()),
         ):
-            config.initialize()
+            config.remove_directory("HOME")
 
-        # Verify the hierarchy was parsed correctly
-        data = config.read()
-        assert len(data["hierarchy"]) == 3
-        assert data["hierarchy"][0]["name"] == "org"
-        assert data["hierarchy"][1]["name"] == "team"
-        assert data["hierarchy"][2]["name"] == "personal"
+        with open(config.config_file) as f:
+            raw = yaml.safe_load(f)
+        assert "HOME" not in raw["directories"]
 
-    def test_initialize_strips_whitespace_from_hierarchy(self, tmp_path):
-        """Test that initialize strips whitespace from comma-separated levels."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
+    def test_remove_directory_not_found(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        _write_config(config, _minimal_config())
+        with (
+            patch("agent_manager.config.config.message"),
+            patch("agent_manager.config.config.create_repo", return_value=Mock()),
+            pytest.raises(SystemExit),
+        ):
+            config.remove_directory("ghost")
+
+
+# ===========================================================================
+# set_defaults / get_defaults
+# ===========================================================================
+class TestDefaults:
+
+    def test_set_and_get_defaults(self, tmp_path):
+        config = Config(config_dir=tmp_path)
+        _write_config(config, _minimal_config())
 
         with (
             patch("agent_manager.config.config.message"),
-            patch(
-                "builtins.input",
-                side_effect=["  org  ,  team  ", "url1", "url2"],
-            ),
-            patch("agent_manager.config.config.Config.detect_repo_types", return_value=["git"]),
-            patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
+            patch("agent_manager.config.config.create_repo", return_value=Mock()),
         ):
-            config.initialize()
+            config.set_defaults(repos=["org"], agents=["cursor"])
 
-        data = config.read()
-        assert data["hierarchy"][0]["name"] == "org"
-        assert data["hierarchy"][1]["name"] == "team"
+        defaults = config.get_defaults()
+        assert defaults["default_hierarchy"] == ["org"]
+        assert defaults["default_agents"] == ["cursor"]
 
-    def test_initialize_accepts_python_list_syntax(self, tmp_path):
-        """Test that initialize still accepts Python list syntax for backward compatibility."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
-
-        with (
-            patch("agent_manager.config.config.message"),
-            patch("builtins.input", side_effect=['["org", "team"]', "url1", "url2"]),
-            patch("agent_manager.config.config.Config.detect_repo_types", return_value=["git"]),
-            patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
-        ):
-            config.initialize()
-
-        data = config.read()
-        assert len(data["hierarchy"]) == 2
-        assert data["hierarchy"][0]["name"] == "org"
-        assert data["hierarchy"][1]["name"] == "team"
-
-    def test_initialize_rejects_empty_hierarchy_entries(self, tmp_path):
-        """Test that initialize rejects empty hierarchy entries."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
-
-        with (
-            patch("agent_manager.config.config.message"),
-            patch(
-                "builtins.input",
-                side_effect=["org, , team", "org, team", "url1", "url2"],
-            ),
-            patch("agent_manager.config.config.Config.detect_repo_types", return_value=["git"]),
-            patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
-        ):
-            config.initialize()
-
-        # Should have retried and accepted the valid input
-        data = config.read()
-        assert len(data["hierarchy"]) == 2
+    def test_get_defaults_no_file(self, tmp_path):
+        config = Config(config_dir=tmp_path / "x")
+        defaults = config.get_defaults()
+        assert defaults == {"default_hierarchy": [], "default_agents": []}
 
 
-class TestConfigNormalizeUrl:
-    """Test cases for normalize_url static method."""
+# ===========================================================================
+# generate_template
+# ===========================================================================
+class TestGenerateTemplate:
 
-    def test_normalizes_relative_file_url(self, tmp_path):
-        """Test that relative file:// URLs are resolved to absolute paths."""
-        # Create a test directory
-        test_dir = tmp_path / "test_repo"
-        test_dir.mkdir()
+    def test_template_is_valid_yaml(self):
+        template = Config.generate_template()
+        parsed = yaml.safe_load(template)
+        assert "repos" in parsed
+        assert "default_hierarchy" in parsed
+        assert "directories" in parsed
 
-        # Change to tmp_path directory
-        import os
 
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(tmp_path)
-
-            # Test with relative path
-            url = "file://./test_repo"
-            normalized = Config.normalize_url(url)
-
-            # Should be absolute
-            assert normalized.startswith("file://")
-            assert str(test_dir) in normalized
-            assert "./" not in normalized
-        finally:
-            os.chdir(original_cwd)
-
-    def test_normalizes_relative_file_url_with_parent_dir(self, tmp_path):
-        """Test that relative file:// URLs with parent directory are resolved."""
-        # Create nested structure
-        parent = tmp_path / "parent"
-        parent.mkdir()
-        child = parent / "child"
-        child.mkdir()
-        target = tmp_path / "target"
-        target.mkdir()
-
-        import os
-
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(child)
-
-            # Test with parent directory reference
-            url = "file://../../target"
-            normalized = Config.normalize_url(url)
-
-            # Should be absolute
-            assert normalized.startswith("file://")
-            assert str(target) in normalized
-            assert ".." not in normalized
-        finally:
-            os.chdir(original_cwd)
-
-    def test_normalizes_tilde_in_file_url(self):
-        """Test that tilde (~) in file:// URLs is expanded."""
-        url = "file://~/repos/org"
-        normalized = Config.normalize_url(url)
-
-        # Should expand ~
-        assert "~" not in normalized
-        assert normalized.startswith("file://")
-        assert str(Path.home()) in normalized
-
-    def test_absolute_file_url_remains_unchanged(self, tmp_path):
-        """Test that absolute file:// URLs remain absolute."""
-        test_dir = tmp_path / "test_repo"
-        test_dir.mkdir()
-
-        url = f"file://{test_dir}"
-        normalized = Config.normalize_url(url)
-
-        # Should still be absolute and unchanged (except for potential path normalization)
-        assert normalized.startswith("file://")
-        assert str(test_dir) in normalized
+# ===========================================================================
+# URL utilities (unchanged from V1)
+# ===========================================================================
+class TestNormalizeUrl:
 
     def test_git_url_unchanged(self):
-        """Test that git URLs are not modified."""
         url = "https://github.com/user/repo.git"
-        normalized = Config.normalize_url(url)
+        assert Config.normalize_url(url) == url
 
-        # Should be unchanged
-        assert normalized == url
-
-    def test_ssh_git_url_unchanged(self):
-        """Test that SSH git URLs are not modified."""
+    def test_ssh_url_unchanged(self):
         url = "git@github.com:user/repo.git"
+        assert Config.normalize_url(url) == url
+
+    def test_tilde_expanded(self):
+        url = "file://~/repos/org"
         normalized = Config.normalize_url(url)
-
-        # Should be unchanged
-        assert normalized == url
-
-    def test_other_protocols_unchanged(self):
-        """Test that other protocol URLs are not modified."""
-        url = "s3://bucket/path/to/repo"
-        normalized = Config.normalize_url(url)
-
-        # Should be unchanged
-        assert normalized == url
+        assert "~" not in normalized
+        assert str(Path.home()) in normalized
 
 
-class TestConfigFileUrlResolution:
-    """Integration tests for file:// URL resolution in config operations."""
+class TestDetectRepoTypes:
 
-    def test_initialize_resolves_relative_file_urls(self, tmp_path):
-        """Test that initialize resolves relative file:// URLs to absolute paths."""
-        config_dir = tmp_path / "config"
-        repos_dir = tmp_path / "repos"
-        repos_dir.mkdir()
+    @patch("agent_manager.config.config.discover_repo_types")
+    def test_single_match(self, mock_discover):
+        mock_repo = Mock()
+        mock_repo.REPO_TYPE = "git"
+        mock_repo.can_handle_url.return_value = True
+        mock_discover.return_value = [mock_repo]
+        assert Config.detect_repo_types("https://github.com/x") == ["git"]
 
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
-
-        import os
-
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(tmp_path)
-
-            with (
-                patch("agent_manager.config.config.message"),
-                patch("builtins.input", side_effect=['["org"]', "file://./repos"]),
-                patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
-                patch(
-                    "agent_manager.config.config.Config.detect_repo_types",
-                    return_value=["file"],
-                ),
-            ):
-                config.initialize()
-
-            # Read back the config
-            with open(config.config_file) as f:
-                written_config = yaml.safe_load(f)
-
-            # URL should be absolute
-            url = written_config["hierarchy"][0]["url"]
-            assert url.startswith("file://")
-            assert "./" not in url
-            assert str(repos_dir) in url
-        finally:
-            os.chdir(original_cwd)
-
-    def test_add_level_resolves_relative_file_urls(self, tmp_path):
-        """Test that add_level resolves relative file:// URLs to absolute paths."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
-
-        # Create initial config with git URL
-        initial_config = {"hierarchy": [{"name": "org", "url": "https://github.com/org/repo", "repo_type": "git"}]}
-        with open(config.config_file, "w") as f:
-            yaml.dump(initial_config, f)
-
-        # Create a local repo directory
-        local_repo = tmp_path / "local"
-        local_repo.mkdir()
-
-        import os
-
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(tmp_path)
-
-            with (
-                patch("agent_manager.config.config.message"),
-                patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
-                patch(
-                    "agent_manager.config.config.Config.detect_repo_types",
-                    return_value=["file"],
-                ),
-                patch("agent_manager.config.config.create_repo"),
-            ):
-                config.add_level("personal", "file://./local")
-
-            # Read back the config
-            with open(config.config_file) as f:
-                written_config = yaml.safe_load(f)
-
-            # New URL should be absolute
-            personal_entry = [e for e in written_config["hierarchy"] if e["name"] == "personal"][0]
-            url = personal_entry["url"]
-            assert url.startswith("file://")
-            assert "./" not in url
-            assert str(local_repo) in url
-        finally:
-            os.chdir(original_cwd)
-
-    def test_update_level_resolves_relative_file_urls(self, tmp_path):
-        """Test that update_level resolves relative file:// URLs to absolute paths."""
-        config_dir = tmp_path / "config"
-        config = Config(config_dir=config_dir)
-        config.ensure_directories()
-
-        # Create initial config
-        initial_config = {"hierarchy": [{"name": "org", "url": "https://github.com/org/repo", "repo_type": "git"}]}
-        with open(config.config_file, "w") as f:
-            yaml.dump(initial_config, f)
-
-        # Create a new local repo directory
-        new_local = tmp_path / "new_local"
-        new_local.mkdir()
-
-        import os
-
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(tmp_path)
-
-            with (
-                patch("agent_manager.config.config.message"),
-                patch("agent_manager.config.config.Config.validate_repo_url", return_value=True),
-                patch(
-                    "agent_manager.config.config.Config.detect_repo_types",
-                    return_value=["file"],
-                ),
-                patch("agent_manager.config.config.create_repo"),
-            ):
-                config.update_level("org", new_url="file://./new_local")
-
-            # Read back the config
-            with open(config.config_file) as f:
-                written_config = yaml.safe_load(f)
-
-            # Updated URL should be absolute
-            url = written_config["hierarchy"][0]["url"]
-            assert url.startswith("file://")
-            assert "./" not in url
-            assert str(new_local) in url
-        finally:
-            os.chdir(original_cwd)
+    @patch("agent_manager.config.config.discover_repo_types")
+    def test_no_match(self, mock_discover):
+        mock_repo = Mock()
+        mock_repo.can_handle_url.return_value = False
+        mock_discover.return_value = [mock_repo]
+        assert Config.detect_repo_types("bad://x") == []
 
 
-class TestConfigEdgeCases:
-    """Test cases for edge cases and special scenarios."""
+class TestPromptForRepoType:
 
-    def test_config_with_unicode_paths(self, tmp_path):
-        """Test Config with Unicode characters in paths."""
-        config_dir = tmp_path / "配置"
-        config = Config(config_dir=config_dir)
-
+    @patch("builtins.input", return_value="1")
+    def test_returns_selection(self, _mock_input):
         with patch("agent_manager.config.config.message"):
-            config.ensure_directories()
+            selected = Config.prompt_for_repo_type("url", ["git", "file"])
+        assert selected == "git"
 
-        assert config_dir.exists()
-
-    def test_validates_config_with_additional_fields(self):
-        """Test that validation allows additional fields."""
-        config = {
-            "hierarchy": [
-                {
-                    "name": "org",
-                    "url": "https://github.com/org/repo",
-                    "repo_type": "git",
-                    "extra_field": "extra_value",
-                }
-            ],
-            "mergers": {"JsonMerger": {"indent": 2}},
-        }
-
-        # Should not raise exception
-        Config.validate(config)
+    @patch("builtins.input", side_effect=["bad", "0", "2"])
+    def test_retries_on_bad_input(self, mock_input):
+        with patch("agent_manager.config.config.message"):
+            selected = Config.prompt_for_repo_type("url", ["a", "b"])
+        assert selected == "b"
+        assert mock_input.call_count == 3

--- a/tests/plugins/agents/test_agent.py
+++ b/tests/plugins/agents/test_agent.py
@@ -1,4 +1,4 @@
-"""Tests for plugins/agents/agent.py - Abstract agent base class."""
+"""Tests for plugins/agents/agent.py - V2 Abstract agent base class."""
 
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -11,876 +11,515 @@ from agent_manager.plugins.agents.agent import AbstractAgent
 class ConcreteAgent(AbstractAgent):
     """Concrete implementation for testing AbstractAgent."""
 
-    # Use a test agent directory name
-    agent_directory: Path = Path.home() / ".testagent"
-
-    # Set the repo directory name explicitly so it doesn't change if agent_directory is overridden
-    _repo_directory_name: str = ".testagent"
-
-    @property
-    def scopes(self) -> dict:
-        """Define test scopes."""
-        from agent_manager.plugins.agents import ScopeConfig
-
-        return {
-            "default": ScopeConfig(
-                directory=self.agent_directory,
-                description="Test scope",
-            ),
-        }
+    agent_subdirectory = ".testagent"
 
     def register_hooks(self) -> None:
-        """Concrete implementation of register_hooks."""
-        # For testing, register some sample hooks
-        self.pre_merge_hooks["test.txt"] = self._test_pre_hook
+        self.pre_merge_hooks["*test.txt"] = self._test_pre_hook
         self.post_merge_hooks["*.md"] = self._test_post_hook
 
-    def _test_pre_hook(self, content: str, entry: dict, file_path: Path) -> str:
-        """Sample pre-merge hook for testing."""
+    def _test_pre_hook(
+        self, content: str, repo_name: str, file_path: Path
+    ) -> str:
         return content + "\n# Pre-hook applied"
 
-    def _test_post_hook(self, content: str, file_name: str, sources: list[str]) -> str:
-        """Sample post-merge hook for testing."""
+    def _test_post_hook(
+        self, content: str, file_name: str, sources: list[str]
+    ) -> str:
         return content + f"\n# Post-hook applied from {len(sources)} sources"
 
 
-class TestAbstractAgentInitialization:
-    """Test cases for AbstractAgent initialization."""
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _make_repo(tmp_path: Path, name: str, files: dict[str, str]) -> Mock:
+    """Create a mock repo with files on disk.
+
+    Args:
+        tmp_path: Base temp directory
+        name: Repo directory name
+        files: Mapping of relative paths to contents
+    """
+    repo_path = tmp_path / name
+    repo_path.mkdir(parents=True, exist_ok=True)
+    for rel, content in files.items():
+        fpath = repo_path / rel
+        fpath.parent.mkdir(parents=True, exist_ok=True)
+        fpath.write_text(content)
+    repo = Mock()
+    repo.get_path.return_value = repo_path
+    return repo
+
+
+# ===========================================================================
+# Initialization
+# ===========================================================================
+class TestAbstractAgentInit:
 
     def test_initialization(self):
-        """Test basic agent initialization."""
         agent = ConcreteAgent()
-
         assert agent.pre_merge_hooks is not None
         assert agent.post_merge_hooks is not None
         assert agent.exclude_patterns is not None
         assert agent.merger_registry is not None
 
     def test_exclude_patterns_include_base(self):
-        """Test that exclude patterns include BASE_EXCLUDE_PATTERNS."""
         agent = ConcreteAgent()
-
-        # Should include base patterns
         assert ".git" in agent.exclude_patterns
         assert "__pycache__" in agent.exclude_patterns
-        assert "*.pyc" in agent.exclude_patterns
 
     def test_register_hooks_called(self):
-        """Test that register_hooks is called during initialization."""
         agent = ConcreteAgent()
-
-        # ConcreteAgent registers hooks in register_hooks()
-        assert "test.txt" in agent.pre_merge_hooks
+        assert "*test.txt" in agent.pre_merge_hooks
         assert "*.md" in agent.post_merge_hooks
 
-    def test_home_directory_set(self):
-        """Test that home_directory is set."""
+    def test_get_agent_name(self):
         agent = ConcreteAgent()
+        assert agent.get_agent_name() == "testagent"
 
-        assert agent.home_directory == Path.home()
+    def test_cannot_instantiate_abstract(self):
+        with pytest.raises(TypeError):
+            AbstractAgent()
 
-    def test_agent_directory_set(self):
-        """Test that agent_directory is set."""
-        agent = ConcreteAgent()
+    def test_must_implement_agent_subdirectory(self):
+        class Incomplete(AbstractAgent):
+            pass
 
-        assert agent.agent_directory == Path.home() / ".testagent"
+        with pytest.raises(TypeError):
+            Incomplete()
 
 
-class TestAbstractAgentExcludePatterns:
-    """Test cases for exclude pattern management."""
+# ===========================================================================
+# Exclude patterns
+# ===========================================================================
+class TestExcludePatterns:
 
-    def test_base_exclude_patterns(self):
-        """Test that BASE_EXCLUDE_PATTERNS contains expected patterns."""
+    def test_base_patterns(self):
         patterns = AbstractAgent.BASE_EXCLUDE_PATTERNS
-
         assert ".git" in patterns
-        assert ".gitignore" in patterns
-        assert "__pycache__" in patterns
         assert "*.pyc" in patterns
-        assert ".DS_Store" in patterns
-        assert "README.md" in patterns
-        assert ".venv" in patterns
 
-    def test_get_additional_excludes_default(self):
-        """Test that get_additional_excludes returns empty list by default."""
-        agent = ConcreteAgent()
-
-        additional = agent.get_additional_excludes()
-
-        assert additional == []
-
-    def test_exclude_patterns_are_combined(self):
-        """Test that exclude patterns combine base and additional."""
-
-        class AgentWithExcludes(AbstractAgent):
-            @property
-            def scopes(self):
-                from agent_manager.plugins.agents import ScopeConfig
-
-                return {"default": ScopeConfig(directory=Path.home() / ".test", description="Test")}
+    def test_additional_excludes(self):
+        class CustomAgent(AbstractAgent):
+            agent_subdirectory = ".custom"
 
             def get_additional_excludes(self):
                 return ["custom.txt", "*.log"]
 
-        agent = AgentWithExcludes()
-
-        # Should have both base and custom patterns
-        assert ".git" in agent.exclude_patterns
+        agent = CustomAgent()
         assert "custom.txt" in agent.exclude_patterns
         assert "*.log" in agent.exclude_patterns
+        assert ".git" in agent.exclude_patterns
 
 
-class TestAbstractAgentRootLevelFiles:
-    """Test cases for root-level file discovery configuration."""
+# ===========================================================================
+# Root-level files
+# ===========================================================================
+class TestRootLevelFiles:
 
-    def test_base_root_level_files_exists(self):
-        """Test that BASE_ROOT_LEVEL_FILES class attribute exists."""
-        assert hasattr(AbstractAgent, "BASE_ROOT_LEVEL_FILES")
-        assert isinstance(AbstractAgent.BASE_ROOT_LEVEL_FILES, list)
-
-    def test_base_root_level_files_contains_agents_md(self):
-        """Test that BASE_ROOT_LEVEL_FILES contains AGENTS.md."""
+    def test_base_root_level_files(self):
         assert "AGENTS.md" in AbstractAgent.BASE_ROOT_LEVEL_FILES
 
-    def test_get_additional_root_level_files_default(self):
-        """Test that get_additional_root_level_files() returns empty list by default."""
+    def test_default_additional_empty(self):
         agent = ConcreteAgent()
-        additional = agent.get_additional_root_level_files()
+        assert agent.get_additional_root_level_files() == []
 
-        assert isinstance(additional, list)
-        assert len(additional) == 0
-
-    def test_get_root_level_files_combines_base_and_additional(self):
-        """Test that _get_root_level_files() combines BASE and additional files."""
+    def test_combined(self):
         agent = ConcreteAgent()
         files = agent._get_root_level_files()
-
-        # Should contain at least AGENTS.md from BASE
         assert "AGENTS.md" in files
-        assert isinstance(files, list)
 
-    def test_get_root_level_files_with_custom_agent(self):
-        """Test that agent-specific root-level files are included."""
-
+    def test_custom_root_files(self):
         class CustomAgent(AbstractAgent):
-            @property
-            def scopes(self):
-                from agent_manager.plugins.agents import ScopeConfig
+            agent_subdirectory = ".custom"
 
-                return {"default": ScopeConfig(directory=Path.home() / ".testagent", description="Test")}
-
-            def get_additional_root_level_files(self) -> list[str]:
-                return ["CUSTOM.md", "AGENT.txt"]
+            def get_additional_root_level_files(self):
+                return ["CUSTOM.md"]
 
         agent = CustomAgent()
         files = agent._get_root_level_files()
-
-        # Should have both BASE and custom files
         assert "AGENTS.md" in files
         assert "CUSTOM.md" in files
-        assert "AGENT.txt" in files
 
 
-class TestAbstractAgentFileDiscovery:
-    """Test cases for file discovery."""
+# ===========================================================================
+# File discovery
+# ===========================================================================
+class TestFileDiscovery:
 
-    def test_discover_files_finds_root_files(self, tmp_path):
-        """Test that _discover_files finds files in agent directory."""
-        # Create agent directory and test files
+    def test_finds_agent_dir_files(self, tmp_path):
         agent_dir = tmp_path / ".testagent"
         agent_dir.mkdir()
         (agent_dir / "config.yaml").touch()
         (agent_dir / "settings.json").touch()
-        (agent_dir / ".cursorrules").touch()
 
         agent = ConcreteAgent()
-        files = agent._discover_files(tmp_path)
+        names = [f.name for f in agent._discover_files(tmp_path)]
+        assert "config.yaml" in names
+        assert "settings.json" in names
 
-        file_names = [f.name for f in files]
-        assert "config.yaml" in file_names
-        assert "settings.json" in file_names
-        # Dot files like .cursorrules are legitimate config files and should be found
-        assert ".cursorrules" in file_names
-
-    def test_discover_files_excludes_directories(self, tmp_path):
-        """Test that _discover_files recursively finds files but excludes directories."""
+    def test_excludes_patterns(self, tmp_path):
         agent_dir = tmp_path / ".testagent"
         agent_dir.mkdir()
         (agent_dir / "config.yaml").touch()
-        (agent_dir / "subdir").mkdir()
-        (agent_dir / "subdir" / "nested.txt").touch()
+        (agent_dir / "README.md").touch()
+        (agent_dir / ".DS_Store").touch()
 
         agent = ConcreteAgent()
-        files = agent._discover_files(tmp_path)
+        names = [f.name for f in agent._discover_files(tmp_path)]
+        assert "config.yaml" in names
+        assert "README.md" not in names
+        assert ".DS_Store" not in names
 
-        # Should include both config.yaml and nested.txt (recursive search)
-        file_names = [f.name for f in files]
-        assert "config.yaml" in file_names
-        assert "nested.txt" in file_names
-        assert len(files) == 2
-
-    def test_discover_files_excludes_patterns(self, tmp_path):
-        """Test that _discover_files excludes files matching exclude patterns."""
+    def test_recursive_discovery(self, tmp_path):
         agent_dir = tmp_path / ".testagent"
-        agent_dir.mkdir()
-        (agent_dir / "config.yaml").touch()
-        (agent_dir / "README.md").touch()  # Excluded by BASE_EXCLUDE_PATTERNS
-        (agent_dir / ".DS_Store").touch()  # Excluded (hidden file)
+        (agent_dir / "sub").mkdir(parents=True)
+        (agent_dir / "root.txt").touch()
+        (agent_dir / "sub" / "nested.txt").touch()
 
         agent = ConcreteAgent()
-        files = agent._discover_files(tmp_path)
+        names = [f.name for f in agent._discover_files(tmp_path)]
+        assert "root.txt" in names
+        assert "nested.txt" in names
 
-        file_names = [f.name for f in files]
-        assert "config.yaml" in file_names
-        assert "README.md" not in file_names
-        assert ".DS_Store" not in file_names
+    def test_empty_repo(self, tmp_path):
+        agent = ConcreteAgent()
+        assert agent._discover_files(tmp_path) == []
 
-    def test_discover_files_excludes_wildcard_patterns(self, tmp_path):
-        """Test that _discover_files handles wildcard patterns."""
-        agent_dir = tmp_path / ".testagent"
-        agent_dir.mkdir()
-        (agent_dir / "config.yaml").touch()
-        (agent_dir / "test.pyc").touch()  # Excluded by *.pyc
+    def test_empty_agent_dir(self, tmp_path):
+        (tmp_path / ".testagent").mkdir()
+        agent = ConcreteAgent()
+        assert agent._discover_files(tmp_path) == []
+
+    def test_ignores_other_agent_dirs(self, tmp_path):
+        our = tmp_path / ".testagent"
+        our.mkdir()
+        (our / "ours.txt").touch()
+
+        other = tmp_path / ".other"
+        other.mkdir()
+        (other / "theirs.txt").touch()
 
         agent = ConcreteAgent()
-        files = agent._discover_files(tmp_path)
+        names = [f.name for f in agent._discover_files(tmp_path)]
+        assert "ours.txt" in names
+        assert "theirs.txt" not in names
 
-        file_names = [f.name for f in files]
-        assert "config.yaml" in file_names
-        assert "test.pyc" not in file_names
-
-    def test_discover_files_returns_sorted(self, tmp_path):
-        """Test that _discover_files returns files in sorted order."""
-        agent_dir = tmp_path / ".testagent"
-        agent_dir.mkdir()
-        (agent_dir / "zebra.txt").touch()
-        (agent_dir / "alpha.txt").touch()
-        (agent_dir / "middle.txt").touch()
-
-        agent = ConcreteAgent()
-        files = agent._discover_files(tmp_path)
-
-        file_names = [f.name for f in files]
-        assert file_names == ["alpha.txt", "middle.txt", "zebra.txt"]
-
-    def test_discover_files_handles_empty_directory(self, tmp_path):
-        """Test that _discover_files handles repos without agent directory."""
-        agent = ConcreteAgent()
-        files = agent._discover_files(tmp_path)
-
-        # No .testagent directory exists, should return empty
-        assert files == []
-
-    def test_discover_files_handles_empty_agent_directory(self, tmp_path):
-        """Test that _discover_files handles empty agent directories."""
-        agent_dir = tmp_path / ".testagent"
-        agent_dir.mkdir()
-
-        agent = ConcreteAgent()
-        files = agent._discover_files(tmp_path)
-
-        assert files == []
-
-    def test_discover_files_finds_nested_files(self, tmp_path):
-        """Test that _discover_files recursively finds nested files."""
-        agent_dir = tmp_path / ".testagent"
-        (agent_dir / "agents").mkdir(parents=True)
-        (agent_dir / "commands").mkdir(parents=True)
-        (agent_dir / "agents" / "JIRA.md").touch()
-        (agent_dir / "commands" / "test.txt").touch()
-        (agent_dir / "root.yaml").touch()
-
-        agent = ConcreteAgent()
-        files = agent._discover_files(tmp_path)
-
-        file_names = [f.name for f in files]
-        assert "JIRA.md" in file_names
-        assert "test.txt" in file_names
-        assert "root.yaml" in file_names
-        assert len(files) == 3
-
-    def test_discover_files_ignores_other_agent_directories(self, tmp_path):
-        """Test that _discover_files only finds files in its own agent directory."""
-        # Create files for .testagent (our agent)
-        testagent_dir = tmp_path / ".testagent"
-        testagent_dir.mkdir()
-        (testagent_dir / "my-config.yaml").touch()
-        (testagent_dir / "my-rules.txt").touch()
-
-        # Create files for .otherapp (different agent)
-        otherapp_dir = tmp_path / ".otherapp"
-        otherapp_dir.mkdir()
-        (otherapp_dir / "other-config.yaml").touch()
-        (otherapp_dir / "other-rules.txt").touch()
-
-        # Create files at repo root (should be ignored)
-        (tmp_path / "root-config.yaml").touch()
-
-        agent = ConcreteAgent()
-        files = agent._discover_files(tmp_path)
-
-        file_names = [f.name for f in files]
-        # Should only find files from .testagent
-        assert "my-config.yaml" in file_names
-        assert "my-rules.txt" in file_names
-        # Should NOT find files from .otherapp or root
-        assert "other-config.yaml" not in file_names
-        assert "other-rules.txt" not in file_names
-        assert "root-config.yaml" not in file_names
-        assert len(files) == 2
-
-    def test_merge_configurations_preserves_directory_structure(self, tmp_path):
-        """Test that merge_configurations preserves subdirectory structure."""
-        # Create repo with nested directory structure
-        org_path = tmp_path / "org"
-        org_path.mkdir()
-
-        # Create nested structure in .testagent
-        (org_path / ".testagent" / "agents").mkdir(parents=True)
-        (org_path / ".testagent" / "commands").mkdir(parents=True)
-        (org_path / ".testagent" / "agents" / "JIRA.md").write_text("# JIRA Agent")
-        (org_path / ".testagent" / "commands" / "test.md").write_text("# Test Command")
-        (org_path / ".testagent" / "root.yaml").write_text("root: true")
-
-        org_repo = Mock()
-        org_repo.get_path.return_value = org_path
-
-        config = {"hierarchy": [{"name": "org", "repo": org_repo}]}
-
-        agent = ConcreteAgent()
-        agent.agent_directory = tmp_path / "output"
-        agent.agent_directory.mkdir()
-
-        with patch("agent_manager.plugins.agents.agent.message"):
-            agent.merge_configurations(config)
-
-        # Verify directory structure is preserved
-        assert (agent.agent_directory / "agents" / "JIRA.md").exists()
-        assert (agent.agent_directory / "commands" / "test.md").exists()
-        assert (agent.agent_directory / "root.yaml").exists()
-
-        # Verify content
-        jira_content = (agent.agent_directory / "agents" / "JIRA.md").read_text()
-        assert "# JIRA Agent" in jira_content
-
-
-class TestAbstractAgentRootLevelDiscovery:
-    """Test cases for root-level file discovery in _discover_files."""
-
-    def test_discover_root_level_agents_md(self, tmp_path):
-        """Test that _discover_files finds AGENTS.md at repository root."""
-        # Create AGENTS.md at repo root
+    def test_root_level_agents_md(self, tmp_path):
         (tmp_path / "AGENTS.md").write_text("# Agents")
 
         agent = ConcreteAgent()
-        files = agent._discover_files(tmp_path)
+        names = [f.name for f in agent._discover_files(tmp_path)]
+        assert "AGENTS.md" in names
 
-        file_names = [f.name for f in files]
-        assert "AGENTS.md" in file_names
-        assert len(files) == 1
-
-    def test_discover_both_root_and_subdirectory_files(self, tmp_path):
-        """Test discovering both root-level and subdirectory files."""
-        # Root-level file
-        (tmp_path / "AGENTS.md").write_text("# Root Agents")
-
-        # Subdirectory file
+    def test_root_level_before_subdir(self, tmp_path):
+        (tmp_path / "AGENTS.md").write_text("root")
         agent_dir = tmp_path / ".testagent"
         agent_dir.mkdir()
-        (agent_dir / "config.yaml").write_text("config: true")
+        (agent_dir / "AGENTS.md").write_text("subdir")
 
         agent = ConcreteAgent()
         files = agent._discover_files(tmp_path)
+        agents_files = [f for f in files if f.name == "AGENTS.md"]
+        assert len(agents_files) == 2
+        # Root-level should be first
+        assert agents_files[0].parent == tmp_path
 
-        file_names = [f.name for f in files]
-        assert "AGENTS.md" in file_names
-        assert "config.yaml" in file_names
-        assert len(files) == 2
-
-    def test_discover_files_root_before_subdirectory(self, tmp_path):
-        """Test that root-level files come before subdirectory files in results."""
-        repo_dir = tmp_path / "repo"
-        repo_dir.mkdir()
-
-        # Create AGENTS.md in both root and subdirectory
-        (repo_dir / "AGENTS.md").write_text("# Root level")
-
-        agent_dir = repo_dir / ".testagent"
+    def test_sorted_results(self, tmp_path):
+        agent_dir = tmp_path / ".testagent"
         agent_dir.mkdir()
-        (agent_dir / "AGENTS.md").write_text("# Subdirectory level")
+        (agent_dir / "z.txt").touch()
+        (agent_dir / "a.txt").touch()
 
         agent = ConcreteAgent()
-        files = agent._discover_files(repo_dir)
+        names = [f.name for f in agent._discover_files(tmp_path)]
+        assert names == ["a.txt", "z.txt"]
 
-        agents_md_files = [f for f in files if f.name == "AGENTS.md"]
-        assert len(agents_md_files) == 2
 
-        root_agents = [f for f in agents_md_files if f.parent == repo_dir]
-        subdir_agents = [f for f in agents_md_files if f.parent != repo_dir]
+# ===========================================================================
+# Merge configurations (V2 interface)
+# ===========================================================================
+class TestMergeConfigurations:
 
-        root_index = files.index(root_agents[0])
-        subdir_index = files.index(subdir_agents[0])
-
-        assert root_index < subdir_index, (
-            f"Root-level AGENTS.md should come before subdirectory AGENTS.md "
-            f"(root at index {root_index}, subdirectory at index {subdir_index})"
+    def test_merges_from_repos(self, tmp_path):
+        org_repo = _make_repo(
+            tmp_path, "org", {".testagent/config.yaml": "org: true"}
+        )
+        team_repo = _make_repo(
+            tmp_path, "team", {".testagent/config.yaml": "team: true"}
         )
 
-    def test_discover_missing_root_level_files_gracefully(self, tmp_path):
-        """Test that missing root-level files don't cause errors."""
-        # Only create subdirectory files, no root-level AGENTS.md
-        agent_dir = tmp_path / ".testagent"
-        agent_dir.mkdir()
-        (agent_dir / "config.yaml").write_text("config: true")
+        repos = [
+            {"name": "org", "repo": org_repo},
+            {"name": "team", "repo": team_repo},
+        ]
+
+        base_dir = tmp_path / "target"
+        base_dir.mkdir()
 
         agent = ConcreteAgent()
-        files = agent._discover_files(tmp_path)
-
-        # Should only find the subdirectory file
-        file_names = [f.name for f in files]
-        assert "config.yaml" in file_names
-        assert "AGENTS.md" not in file_names
-        assert len(files) == 1
-
-
-class TestAbstractAgentGetAgentDirectory:
-    """Test cases for get_agent_directory method."""
-
-    def test_get_agent_directory_returns_path(self):
-        """Test that get_agent_directory returns the agent_directory."""
-        agent = ConcreteAgent()
-
-        directory = agent.get_agent_directory()
-
-        assert directory == agent.agent_directory
-        assert isinstance(directory, Path)
-
-
-class TestAbstractAgentRunHook:
-    """Test cases for hook execution."""
-
-    def test_run_hook_executes_matching_hook(self, tmp_path):
-        """Test that _run_hook executes hooks for matching patterns."""
-        agent = ConcreteAgent()
-
-        content = "Original content"
-        entry = {"name": "test"}
-        file_path = tmp_path / "test.txt"
-
-        # Run hook (test.txt matches registered pre-hook)
-        result = agent._run_hook(agent.pre_merge_hooks, "test.txt", content, entry, file_path)
-
-        assert "# Pre-hook applied" in result
-
-    def test_run_hook_executes_wildcard_pattern(self, tmp_path):
-        """Test that _run_hook handles wildcard patterns."""
-        agent = ConcreteAgent()
-
-        content = "Original content"
-        sources = ["org", "team"]
-
-        # Run hook (*.md matches registered post-hook)
-        result = agent._run_hook(agent.post_merge_hooks, "README.md", content, None, None, sources)
-
-        assert "# Post-hook applied from 2 sources" in result
-
-    def test_run_hook_no_match(self, tmp_path):
-        """Test that _run_hook returns content unchanged when no hook matches."""
-        agent = ConcreteAgent()
-
-        content = "Original content"
-        entry = {"name": "test"}
-        file_path = tmp_path / "no-match.xyz"
-
-        result = agent._run_hook(agent.pre_merge_hooks, "no-match.xyz", content, entry, file_path)
-
-        assert result == content
-
-    def test_run_hook_handles_exception(self, tmp_path):
-        """Test that _run_hook handles hook exceptions gracefully."""
-
-        class FaultyAgent(AbstractAgent):
-            @property
-            def scopes(self):
-                from agent_manager.plugins.agents import ScopeConfig
-
-                return {"default": ScopeConfig(directory=Path.home() / ".test", description="Test")}
-
-            def register_hooks(self):
-                self.pre_merge_hooks["*.txt"] = self._faulty_hook
-
-            def _faulty_hook(self, content, entry, file_path):
-                raise Exception("Hook error")
-
-        agent = FaultyAgent()
-
-        content = "Original content"
-        entry = {"name": "test"}
-        file_path = tmp_path / "test.txt"
-
         with patch("agent_manager.plugins.agents.agent.message"):
-            result = agent._run_hook(agent.pre_merge_hooks, "test.txt", content, entry, file_path)
+            agent.merge_configurations(repos, base_dir)
 
-            # Should return original content despite error
-            assert result == content
+        output = base_dir / ".testagent" / "config.yaml"
+        assert output.exists()
 
+    def test_root_level_files_written_to_base(self, tmp_path):
+        repo = _make_repo(
+            tmp_path, "org",
+            {"AGENTS.md": "# Agents from org"},
+        )
 
-class TestAbstractAgentMergeConfigurations:
-    """Test cases for configuration merging."""
-
-    def test_merge_configurations_processes_hierarchy(self, tmp_path):
-        """Test that merge_configurations processes all hierarchy levels."""
-        # Create mock repositories with agent-specific directories
-        org_path = tmp_path / "org"
-        team_path = tmp_path / "team"
-        org_path.mkdir()
-        team_path.mkdir()
-
-        # Create agent directories and files
-        (org_path / ".testagent").mkdir()
-        (team_path / ".testagent").mkdir()
-        (org_path / ".testagent" / "config.yaml").write_text("org: true")
-        (team_path / ".testagent" / "config.yaml").write_text("team: true")
-
-        org_repo = Mock()
-        org_repo.get_path.return_value = org_path
-
-        team_repo = Mock()
-        team_repo.get_path.return_value = team_path
-
-        config = {
-            "hierarchy": [
-                {"name": "org", "repo": org_repo},
-                {"name": "team", "repo": team_repo},
-            ]
-        }
+        base_dir = tmp_path / "target"
+        base_dir.mkdir()
 
         agent = ConcreteAgent()
-        agent.agent_directory = tmp_path / "output"
-        agent.agent_directory.mkdir()
-
         with patch("agent_manager.plugins.agents.agent.message"):
-            agent.merge_configurations(config)
+            agent.merge_configurations(
+                [{"name": "org", "repo": repo}], base_dir,
+            )
 
-        # Should have merged and written config.yaml
-        output_file = agent.agent_directory / "config.yaml"
-        assert output_file.exists()
+        assert (base_dir / "AGENTS.md").exists()
+        content = (base_dir / "AGENTS.md").read_text()
+        assert "Agents from org" in content
 
-    def test_merge_configurations_handles_missing_repo_path(self, tmp_path):
-        """Test that merge_configurations handles missing repository paths."""
-        missing_repo = Mock()
-        missing_repo.get_path.return_value = tmp_path / "nonexistent"
+    def test_preserves_directory_structure(self, tmp_path):
+        repo = _make_repo(tmp_path, "org", {
+            ".testagent/agents/JIRA.md": "# JIRA",
+            ".testagent/commands/test.md": "# Test",
+            ".testagent/root.yaml": "root: true",
+        })
 
-        config = {"hierarchy": [{"name": "missing", "repo": missing_repo}]}
+        base_dir = tmp_path / "target"
+        base_dir.mkdir()
 
         agent = ConcreteAgent()
-        agent.agent_directory = tmp_path / "output"
-        agent.agent_directory.mkdir()
-
         with patch("agent_manager.plugins.agents.agent.message"):
-            agent.merge_configurations(config)
+            agent.merge_configurations(
+                [{"name": "org", "repo": repo}], base_dir,
+            )
 
-        # Should not crash, just skip missing repo
-        output_files = list(agent.agent_directory.iterdir())
-        assert len(output_files) == 0
+        assert (base_dir / ".testagent" / "agents" / "JIRA.md").exists()
+        assert (base_dir / ".testagent" / "commands" / "test.md").exists()
+        assert (base_dir / ".testagent" / "root.yaml").exists()
 
-    def test_merge_configurations_handles_empty_repo(self, tmp_path):
-        """Test that merge_configurations handles repos with no files."""
-        empty_path = tmp_path / "empty"
-        empty_path.mkdir()
+    def test_missing_repo_path_skipped(self, tmp_path):
+        repo = Mock()
+        repo.get_path.return_value = tmp_path / "nonexistent"
 
-        empty_repo = Mock()
-        empty_repo.get_path.return_value = empty_path
-
-        config = {"hierarchy": [{"name": "empty", "repo": empty_repo}]}
+        base_dir = tmp_path / "target"
+        base_dir.mkdir()
 
         agent = ConcreteAgent()
-        agent.agent_directory = tmp_path / "output"
-        agent.agent_directory.mkdir()
-
         with patch("agent_manager.plugins.agents.agent.message"):
-            agent.merge_configurations(config)
+            agent.merge_configurations(
+                [{"name": "bad", "repo": repo}], base_dir,
+            )
 
-        # Should not crash
-        output_files = list(agent.agent_directory.iterdir())
-        assert len(output_files) == 0
+    def test_empty_repo_skipped(self, tmp_path):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        repo = Mock()
+        repo.get_path.return_value = empty
 
-    def test_merge_configurations_uses_merger_registry(self, tmp_path):
-        """Test that merge_configurations uses the merger registry."""
-        org_path = tmp_path / "org"
-        team_path = tmp_path / "team"
-        org_path.mkdir()
-        team_path.mkdir()
-
-        # Create agent directories and files
-        (org_path / ".testagent").mkdir()
-        (team_path / ".testagent").mkdir()
-        (org_path / ".testagent" / "config.json").write_text('{"org": true}')
-        (team_path / ".testagent" / "config.json").write_text('{"team": true}')
-
-        org_repo = Mock()
-        org_repo.get_path.return_value = org_path
-
-        team_repo = Mock()
-        team_repo.get_path.return_value = team_path
-
-        config = {
-            "hierarchy": [
-                {"name": "org", "repo": org_repo},
-                {"name": "team", "repo": team_repo},
-            ]
-        }
+        base_dir = tmp_path / "target"
+        base_dir.mkdir()
 
         agent = ConcreteAgent()
-        agent.agent_directory = tmp_path / "output"
-        agent.agent_directory.mkdir()
-
         with patch("agent_manager.plugins.agents.agent.message"):
-            agent.merge_configurations(config)
+            agent.merge_configurations(
+                [{"name": "empty", "repo": repo}], base_dir,
+            )
 
-        # Should have merged JSON and written output
-        output_file = agent.agent_directory / "config.json"
-        assert output_file.exists()
+    def test_uses_merger_registry(self, tmp_path):
+        org_repo = _make_repo(
+            tmp_path, "org", {".testagent/config.json": '{"org": true}'}
+        )
+        team_repo = _make_repo(
+            tmp_path, "team", {".testagent/config.json": '{"team": true}'}
+        )
 
-        # Content should be merged (both keys present)
+        base_dir = tmp_path / "target"
+        base_dir.mkdir()
+
+        agent = ConcreteAgent()
+        with patch("agent_manager.plugins.agents.agent.message"):
+            agent.merge_configurations(
+                [
+                    {"name": "org", "repo": org_repo},
+                    {"name": "team", "repo": team_repo},
+                ],
+                base_dir,
+            )
+
         import json
 
-        content = json.loads(output_file.read_text())
-        assert "org" in content
-        assert "team" in content
+        out = base_dir / ".testagent" / "config.json"
+        assert out.exists()
+        data = json.loads(out.read_text())
+        assert "org" in data
+        assert "team" in data
 
-    def test_merge_configurations_applies_pre_merge_hooks(self, tmp_path):
-        """Test that merge_configurations applies pre-merge hooks."""
-        org_path = tmp_path / "org"
-        org_path.mkdir()
+    def test_applies_pre_merge_hooks(self, tmp_path):
+        repo = _make_repo(
+            tmp_path, "org", {".testagent/test.txt": "Content"}
+        )
 
-        # Create agent directory and files
-        (org_path / ".testagent").mkdir()
-        (org_path / ".testagent" / "test.txt").write_text("Content")
-
-        org_repo = Mock()
-        org_repo.get_path.return_value = org_path
-
-        config = {"hierarchy": [{"name": "org", "repo": org_repo}]}
+        base_dir = tmp_path / "target"
+        base_dir.mkdir()
 
         agent = ConcreteAgent()
-        agent.agent_directory = tmp_path / "output"
-        agent.agent_directory.mkdir()
-
         with patch("agent_manager.plugins.agents.agent.message"):
-            agent.merge_configurations(config)
+            agent.merge_configurations(
+                [{"name": "org", "repo": repo}], base_dir,
+            )
 
-        output_file = agent.agent_directory / "test.txt"
-        assert output_file.exists()
-
-        content = output_file.read_text()
+        content = (base_dir / ".testagent" / "test.txt").read_text()
         assert "# Pre-hook applied" in content
 
-    def test_merge_configurations_applies_post_merge_hooks(self, tmp_path):
-        """Test that merge_configurations applies post-merge hooks."""
-        org_path = tmp_path / "org"
-        org_path.mkdir()
+    def test_applies_post_merge_hooks(self, tmp_path):
+        repo = _make_repo(
+            tmp_path, "org", {".testagent/config.md": "# Content"}
+        )
 
-        # Create agent directory and files
-        (org_path / ".testagent").mkdir()
-        (org_path / ".testagent" / "config.md").write_text("# Content")
-
-        org_repo = Mock()
-        org_repo.get_path.return_value = org_path
-
-        config = {"hierarchy": [{"name": "org", "repo": org_repo}]}
+        base_dir = tmp_path / "target"
+        base_dir.mkdir()
 
         agent = ConcreteAgent()
-        agent.agent_directory = tmp_path / "output"
-        agent.agent_directory.mkdir()
-
         with patch("agent_manager.plugins.agents.agent.message"):
-            agent.merge_configurations(config)
+            agent.merge_configurations(
+                [{"name": "org", "repo": repo}], base_dir,
+            )
 
-        output_file = agent.agent_directory / "config.md"
-        assert output_file.exists()
-
-        content = output_file.read_text()
+        content = (base_dir / ".testagent" / "config.md").read_text()
         assert "# Post-hook applied from 1 sources" in content
 
-    def test_merge_configurations_handles_file_read_error(self, tmp_path):
-        """Test that merge_configurations handles file read errors gracefully."""
-        org_path = tmp_path / "org"
-        org_path.mkdir()
+    def test_merger_settings_passed(self, tmp_path):
+        org_repo = _make_repo(
+            tmp_path, "org",
+            {".testagent/config.json": '{"key": "v1"}'},
+        )
+        team_repo = _make_repo(
+            tmp_path, "team",
+            {".testagent/config.json": '{"key": "v2"}'},
+        )
 
-        # Create a file that will cause an error when read
-        # (by making it a directory instead of a file)
-        (org_path / "bad.txt").mkdir()
-
-        org_repo = Mock()
-        org_repo.get_path.return_value = org_path
-
-        config = {"hierarchy": [{"name": "org", "repo": org_repo}]}
+        base_dir = tmp_path / "target"
+        base_dir.mkdir()
 
         agent = ConcreteAgent()
-        agent.agent_directory = tmp_path / "output"
-        agent.agent_directory.mkdir()
-
         with patch("agent_manager.plugins.agents.agent.message"):
-            # Should not crash
-            agent.merge_configurations(config)
+            agent.merge_configurations(
+                [
+                    {"name": "org", "repo": org_repo},
+                    {"name": "team", "repo": team_repo},
+                ],
+                base_dir,
+                merger_settings={"JsonMerger": {"indent": 2}},
+            )
 
-    def test_merge_configurations_handles_file_write_error(self, tmp_path):
-        """Test that merge_configurations handles file write errors gracefully."""
-        org_path = tmp_path / "org"
-        org_path.mkdir()
+        out = base_dir / ".testagent" / "config.json"
+        assert out.exists()
 
-        # Create agent directory and files
-        (org_path / ".testagent").mkdir()
-        (org_path / ".testagent" / "config.yaml").write_text("test: true")
 
-        org_repo = Mock()
-        org_repo.get_path.return_value = org_path
+# ===========================================================================
+# Update (V2 interface)
+# ===========================================================================
+class TestUpdate:
 
-        config = {"hierarchy": [{"name": "org", "repo": org_repo}]}
+    def test_update_creates_dir_and_merges(self, tmp_path):
+        repo = _make_repo(
+            tmp_path, "org", {".testagent/config.yaml": "org: true"}
+        )
+
+        base_dir = tmp_path / "target"
+        base_dir.mkdir()
 
         agent = ConcreteAgent()
-        # Set agent_directory to a file (not a directory) to cause write error
-        bad_output = tmp_path / "bad_output"
-        bad_output.touch()
-        agent.agent_directory = bad_output
-
         with patch("agent_manager.plugins.agents.agent.message"):
-            # Should not crash
-            agent.merge_configurations(config)
+            agent.update(
+                [{"name": "org", "repo": repo}], base_dir,
+            )
+
+        assert (base_dir / ".testagent").exists()
+        assert (base_dir / ".testagent" / "config.yaml").exists()
 
 
-class TestAbstractAgentAbstractMethods:
-    """Test cases for abstract method enforcement."""
+# ===========================================================================
+# Hook execution
+# ===========================================================================
+class TestRunHook:
 
-    def test_cannot_instantiate_abstract_class(self):
-        """Test that AbstractAgent cannot be instantiated directly."""
-        with pytest.raises(TypeError):
-            AbstractAgent()
-
-    def test_must_implement_scopes(self):
-        """Test that subclasses must implement scopes property."""
-
-        class IncompleteAgent(AbstractAgent):
-            # Missing scopes property
-            pass
-
-        with pytest.raises(TypeError):
-            IncompleteAgent()
-
-
-class TestAbstractAgentExceptionHandling:
-    """Test exception handling during file processing."""
-
-    def test_merge_configurations_handles_file_processing_exception(self, tmp_path):
-        """Test that merge_configurations handles exceptions when processing files."""
-        org_path = tmp_path / "org"
-        org_path.mkdir()
-
-        # Create a file that will cause an exception
-        test_file = org_path / "test.json"
-        test_file.write_text("not valid json")
-
-        org_repo = Mock()
-        org_repo.get_path.return_value = org_path
-
-        config = {"hierarchy": [{"name": "org", "repo": org_repo}]}
-
+    def test_matching_pre_hook(self, tmp_path):
         agent = ConcreteAgent()
-        agent.agent_directory = tmp_path / "output"
-        agent.agent_directory.mkdir()
+        result = agent._run_hook(
+            agent.pre_merge_hooks, ".testagent/test.txt",
+            "content", "org", tmp_path / "test.txt",
+        )
+        assert "# Pre-hook applied" in result
 
-        # Make the merger raise an exception
-        with (
-            patch("agent_manager.plugins.agents.agent.message"),
-            patch.object(agent.merger_registry, "get_merger") as mock_get_merger,
-        ):
-            mock_merger = Mock()
-            mock_merger.merge.side_effect = ValueError("Test error")
-            mock_get_merger.return_value = mock_merger
-
-            # Should not raise, just log warning
-            agent.merge_configurations(config)
-
-
-class TestAbstractAgentEdgeCases:
-    """Test cases for edge cases and special scenarios."""
-
-    def test_merge_configurations_with_merger_settings(self, tmp_path):
-        """Test that merge_configurations passes merger settings."""
-        org_path = tmp_path / "org"
-        team_path = tmp_path / "team"
-        org_path.mkdir()
-        team_path.mkdir()
-
-        # Create agent directories and files
-        (org_path / ".testagent").mkdir()
-        (team_path / ".testagent").mkdir()
-        (org_path / ".testagent" / "config.json").write_text('{"key": "value1"}')
-        (team_path / ".testagent" / "config.json").write_text('{"key": "value2"}')
-
-        org_repo = Mock()
-        org_repo.get_path.return_value = org_path
-
-        team_repo = Mock()
-        team_repo.get_path.return_value = team_path
-
-        config = {
-            "hierarchy": [
-                {"name": "org", "repo": org_repo},
-                {"name": "team", "repo": team_repo},
-            ],
-            "mergers": {"JsonMerger": {"indent": 2}},
-        }
-
+    def test_matching_post_hook(self):
         agent = ConcreteAgent()
-        agent.agent_directory = tmp_path / "output"
-        agent.agent_directory.mkdir()
+        result = agent._run_hook(
+            agent.post_merge_hooks, "README.md",
+            "content", None, None, ["org", "team"],
+        )
+        assert "# Post-hook applied from 2 sources" in result
 
+    def test_no_match(self, tmp_path):
+        agent = ConcreteAgent()
+        result = agent._run_hook(
+            agent.pre_merge_hooks, "no-match.xyz",
+            "content", "org", tmp_path / "x",
+        )
+        assert result == "content"
+
+    def test_handles_exception(self, tmp_path):
+        class FaultyAgent(AbstractAgent):
+            agent_subdirectory = ".faulty"
+
+            def register_hooks(self):
+                self.pre_merge_hooks["*.txt"] = self._bad
+
+            def _bad(self, content, name, path):
+                raise RuntimeError("boom")
+
+        agent = FaultyAgent()
         with patch("agent_manager.plugins.agents.agent.message"):
-            agent.merge_configurations(config)
+            result = agent._run_hook(
+                agent.pre_merge_hooks, "test.txt",
+                "original", "org", tmp_path / "test.txt",
+            )
+        assert result == "original"
 
-        # Should have applied merger settings
-        output_file = agent.agent_directory / "config.json"
-        assert output_file.exists()
 
-    def test_discover_files_with_unicode_filenames(self, tmp_path):
-        """Test that _discover_files handles Unicode filenames."""
-        # Create agent directory and files
+# ===========================================================================
+# Edge cases
+# ===========================================================================
+class TestEdgeCases:
+
+    def test_unicode_filenames(self, tmp_path):
         agent_dir = tmp_path / ".testagent"
         agent_dir.mkdir()
         (agent_dir / "配置.yaml").touch()
-        (agent_dir / "Конфигурация.json").touch()
 
         agent = ConcreteAgent()
         files = agent._discover_files(tmp_path)
+        assert len(files) == 1
 
-        assert len(files) == 2
+    def test_unicode_content(self, tmp_path):
+        repo = _make_repo(
+            tmp_path, "org",
+            {".testagent/config.txt": "你好世界 🌍"},
+        )
 
-    def test_merge_configurations_with_unicode_content(self, tmp_path):
-        """Test that merge_configurations handles Unicode content."""
-        org_path = tmp_path / "org"
-        org_path.mkdir()
-
-        # Create agent directory and files
-        (org_path / ".testagent").mkdir()
-        (org_path / ".testagent" / "config.txt").write_text("你好世界 🌍", encoding="utf-8")
-
-        org_repo = Mock()
-        org_repo.get_path.return_value = org_path
-
-        config = {"hierarchy": [{"name": "org", "repo": org_repo}]}
+        base_dir = tmp_path / "target"
+        base_dir.mkdir()
 
         agent = ConcreteAgent()
-        agent.agent_directory = tmp_path / "output"
-        agent.agent_directory.mkdir()
-
         with patch("agent_manager.plugins.agents.agent.message"):
-            agent.merge_configurations(config)
+            agent.merge_configurations(
+                [{"name": "org", "repo": repo}], base_dir,
+            )
 
-        output_file = agent.agent_directory / "config.txt"
-        assert output_file.exists()
-
-        content = output_file.read_text(encoding="utf-8")
+        content = (base_dir / ".testagent" / "config.txt").read_text()
         assert "你好世界" in content
-        assert "🌍" in content

--- a/tests/plugins/repos/test_abstract_repo.py
+++ b/tests/plugins/repos/test_abstract_repo.py
@@ -330,3 +330,36 @@ class TestAbstractRepoEdgeCases:
 
         (symlink_dir / "test").mkdir()
         assert repo.exists() is True
+
+
+class TestDetectDirectory:
+    """Test cases for detect_directory classmethod."""
+
+    def test_nonexistent_directory(self, tmp_path):
+        assert AbstractRepo.detect_directory(tmp_path / "nope") is None
+
+    def test_file_not_directory(self, tmp_path):
+        f = tmp_path / "file.txt"
+        f.touch()
+        assert AbstractRepo.detect_directory(f) is None
+
+    def test_plain_directory_returns_file(self, tmp_path):
+        d = tmp_path / "plain"
+        d.mkdir()
+        assert AbstractRepo.detect_directory(d) == "file"
+
+    def test_git_directory_returns_git(self, tmp_path):
+        d = tmp_path / "gitrepo"
+        d.mkdir()
+        (d / ".git").mkdir()
+        assert AbstractRepo.detect_directory(d) == "git"
+
+
+class TestSafeToOverwrite:
+    """Test cases for safe_to_overwrite on base class."""
+
+    def test_base_always_returns_false(self, tmp_path):
+        repo = ConcreteRepo("test", "test://valid/repo", tmp_path)
+        some_file = tmp_path / "any_file.txt"
+        some_file.touch()
+        assert repo.safe_to_overwrite(some_file) is False

--- a/tests/plugins/repos/test_local_repo.py
+++ b/tests/plugins/repos/test_local_repo.py
@@ -433,3 +433,14 @@ class TestLocalRepoVsGitRepo:
         assert repo.exists()
         assert not repo.needs_update()
         repo.update()  # Should not throw
+
+    def test_safe_to_overwrite_always_false(self, tmp_path):
+        """LocalRepo.safe_to_overwrite always returns False (no VCS)."""
+        test_dir = tmp_path / "test"
+        test_dir.mkdir()
+        (test_dir / "file.txt").write_text("x")
+
+        with patch("agent_manager.plugins.repos.local_repo.message"):
+            repo = LocalRepo("test", f"file://{test_dir}", tmp_path)
+
+        assert not repo.safe_to_overwrite(test_dir / "file.txt")

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -584,7 +584,7 @@ class TestFullIntegration:
         repos_dir.mkdir(parents=True, exist_ok=True)
 
         return {
-            "hierarchy": [
+            "repos": [
                 {
                     "name": "organization",
                     "url": f"file://{test_data_path / 'org'}",
@@ -614,19 +614,20 @@ class TestFullIntegration:
 
         from agent_manager.plugins.agents.test_agent import TestAgent
 
-        # Create TestAgent with temp directory
+        # Create TestAgent with temp directory as the base
         test_agent = TestAgent(temp_dir=temp_output_dir)
 
-        # Run the update
-        test_agent.update(mock_config_data)
+        # V2: pass repos list and base_directory
+        test_agent.update(mock_config_data["repos"], base_directory=temp_output_dir)
 
         # Verify the output directory was created
-        assert temp_output_dir.exists()
+        output_dir = temp_output_dir / ".testagent"
+        assert output_dir.exists()
 
-        # Verify merged files exist
-        merged_cursorrules = temp_output_dir / ".cursorrules"
-        merged_mcp = temp_output_dir / "mcp.json"
-        merged_settings = temp_output_dir / "settings.yaml"
+        # Verify merged files exist (under .testagent subdirectory)
+        merged_cursorrules = output_dir / ".cursorrules"
+        merged_mcp = output_dir / "mcp.json"
+        merged_settings = output_dir / "settings.yaml"
 
         assert merged_cursorrules.exists(), "Merged .cursorrules should exist"
         assert merged_mcp.exists(), "Merged mcp.json should exist"
@@ -634,34 +635,25 @@ class TestFullIntegration:
 
         # Verify .cursorrules content (text merger should concatenate)
         cursorrules_content = merged_cursorrules.read_text()
-        # At minimum, personal content should be present (highest priority)
         assert "Personal Preferences - John's Setup" in cursorrules_content
-        # Note: The TextMerger should concatenate all three, but verifying at least one works
 
         # Verify mcp.json deep merge (JSON merger)
         mcp_data = json.loads(merged_mcp.read_text())
-        # Should have all MCP servers from all three levels
-        assert "company-docs" in mcp_data["mcpServers"]  # from org
-        assert "jira" in mcp_data["mcpServers"]  # from org
-        assert "postgres" in mcp_data["mcpServers"]  # from team
-        assert "redis" in mcp_data["mcpServers"]  # from team
-        assert "aws" in mcp_data["mcpServers"]  # from team
-        assert "filesystem" in mcp_data["mcpServers"]  # from personal
-        assert "git" in mcp_data["mcpServers"]  # from personal
-        assert "localhost" in mcp_data["mcpServers"]  # from personal
-        assert "postgres-local" in mcp_data["mcpServers"]  # from personal
+        assert "company-docs" in mcp_data["mcpServers"]
+        assert "jira" in mcp_data["mcpServers"]
+        assert "postgres" in mcp_data["mcpServers"]
+        assert "redis" in mcp_data["mcpServers"]
+        assert "aws" in mcp_data["mcpServers"]
+        assert "filesystem" in mcp_data["mcpServers"]
+        assert "git" in mcp_data["mcpServers"]
+        assert "localhost" in mcp_data["mcpServers"]
+        assert "postgres-local" in mcp_data["mcpServers"]
 
         # Verify settings.yaml deep merge with overrides (YAML merger)
         settings_data = yaml.safe_load(merged_settings.read_text())
-
-        # Personal overrides should win
-        assert settings_data["python"]["testing"]["min_coverage"] == 90  # personal overrides team's 85
-
-        # Team data should be present
+        assert settings_data["python"]["testing"]["min_coverage"] == 90
         assert "team" in settings_data
         assert settings_data["team"]["name"] == "Backend Engineering"
-
-        # Org data should be present
         assert "organization" in settings_data
         assert settings_data["organization"]["name"] == "ACME Corp"
 
@@ -696,13 +688,11 @@ class TestFullIntegration:
         """Test that TestAgent can be imported and instantiated."""
         from agent_manager.plugins.agents.test_agent import TestAgent
 
-        # Test we can import and create the agent
         agent = TestAgent()
         assert agent is not None
         assert hasattr(agent, "update")
-        assert hasattr(agent, "agent_directory")
+        assert hasattr(agent, "agent_subdirectory")
 
-        # Cleanup
         agent.cleanup()
 
     def test_test_agent_initialization(self):
@@ -713,20 +703,19 @@ class TestFullIntegration:
 
         # Test with auto-generated temp dir
         agent = TestAgent()
-        assert agent.agent_directory.exists()
-        temp_path = agent.agent_directory
+        base = agent.get_base_directory()
+        assert base.exists()
 
         agent.cleanup()
-        assert not temp_path.exists()
+        assert not base.exists()
 
         # Test with provided temp dir
         from tempfile import mkdtemp
 
         custom_temp = Path(mkdtemp())
         agent2 = TestAgent(temp_dir=custom_temp)
-        assert agent2.agent_directory == custom_temp
+        assert agent2.get_base_directory() == custom_temp
 
-        # Cleanup
         import shutil
 
         shutil.rmtree(custom_temp)

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -137,9 +137,9 @@ class TestConfigCommand:
                         args = mock_process.call_args[0][0]
                         assert args.config_command == "show"
 
-    def test_config_add_command(self):
-        """Test config add command with parameters."""
-        with patch("sys.argv", ["agent-manager", "config", "add", "test-level", "https://github.com/test/repo"]):
+    def test_config_defaults_command(self):
+        """Test config defaults command with parameters."""
+        with patch("sys.argv", ["agent-manager", "config", "defaults", "--repos", "org", "personal"]):
             with patch("agent_manager.agent_manager.Config") as mock_config:
                 with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command") as mock_process:
                     with patch("agent_manager.agent_manager.get_output"):
@@ -149,9 +149,8 @@ class TestConfigCommand:
 
                         assert mock_process.called
                         args = mock_process.call_args[0][0]
-                        assert args.config_command == "add"
-                        assert args.name == "test-level"
-                        assert args.url == "https://github.com/test/repo"
+                        assert args.config_command == "defaults"
+                        assert args.repos == ["org", "personal"]
 
     def test_config_command_early_return(self):
         """Test that config command returns early without initializing repos."""
@@ -514,7 +513,7 @@ class TestIntegration:
 
     def test_config_command_workflow(self):
         """Test complete config management workflow."""
-        with patch("sys.argv", ["agent-manager", "-v", "config", "add", "team", "https://github.com/test/team"]):
+        with patch("sys.argv", ["agent-manager", "-v", "config", "show"]):
             with patch("agent_manager.agent_manager.Config") as mock_config:
                 with patch("agent_manager.agent_manager.ConfigCommands.process_cli_command") as mock_process:
                     with patch("agent_manager.agent_manager.get_output") as mock_output:


### PR DESCRIPTION
## Summary

- Add `detect_directory(path)` classmethod to `AbstractRepo` for runtime VCS type detection
- Add `safe_to_overwrite(file_path)` method to `AbstractRepo` (base returns `False`)
- Implement `GitRepo.safe_to_overwrite()` - returns `True` only for tracked files with no uncommitted changes
- `LocalRepo` inherits the conservative `False` default

These methods are used by the safety checks in PR 5 (clobber detection) and the main loop in PR 7.

## Test plan

- [x] 118 repo tests pass
- [x] `ruff check` clean
- [x] Integration tests for `safe_to_overwrite` with real git repos (tracked clean, untracked, modified, outside repo, nonexistent)
- [x] `detect_directory` tested for nonexistent, plain dir, git dir, file


Made with [Cursor](https://cursor.com)