### PR TITLE
PR 6: CLI restructure for V2 architecture

### DIFF
--- a/agent_manager/cli_extensions/__init__.py
+++ b/agent_manager/cli_extensions/__init__.py
@@ -2,12 +2,18 @@
 
 from .agent_commands import AgentCommands
 from .config_commands import ConfigCommands
+from .directory_commands import DirectoryCommands
 from .merger_commands import MergerCommands
+from .plugin_commands import PluginCommands
 from .repo_commands import RepoCommands
+from .repo_config_commands import RepoConfigCommands
 
 __all__ = [
     "AgentCommands",
     "ConfigCommands",
+    "DirectoryCommands",
     "MergerCommands",
+    "PluginCommands",
     "RepoCommands",
+    "RepoConfigCommands",
 ]

--- a/agent_manager/cli_extensions/directory_commands.py
+++ b/agent_manager/cli_extensions/directory_commands.py
@@ -1,0 +1,224 @@
+"""CLI commands for managing target directories in the configuration."""
+
+import argparse
+from pathlib import Path
+
+from agent_manager.config import Config
+from agent_manager.core.manifest import read_manifest
+from agent_manager.output import MessageType, VerbosityLevel, message
+from agent_manager.plugins.repos.abstract_repo import AbstractRepo
+
+
+class DirectoryCommands:
+    """Manages CLI commands for target directories in the config."""
+
+    @staticmethod
+    def add_cli_arguments(subparsers) -> None:
+        """Add directory-related CLI arguments."""
+        dir_parser = subparsers.add_parser(
+            "directory",
+            help="Manage target directories in the configuration",
+        )
+        dir_sub = dir_parser.add_subparsers(
+            dest="directory_command",
+            help="Directory commands",
+        )
+
+        # directory list
+        dir_sub.add_parser(
+            "list",
+            help="List configured target directories",
+        )
+
+        # directory add
+        add_parser = dir_sub.add_parser(
+            "add",
+            help="Add a target directory to the configuration",
+        )
+        add_parser.add_argument(
+            "path",
+            help="Directory path (use HOME for home directory)",
+        )
+        add_parser.add_argument(
+            "--type",
+            dest="dir_type",
+            help="Directory VCS type (auto-detected if omitted)",
+        )
+        add_parser.add_argument(
+            "--agents",
+            nargs="+",
+            metavar="NAME",
+            help="Agent list for this directory",
+        )
+        add_parser.add_argument(
+            "--hierarchy",
+            nargs="+",
+            metavar="REPO",
+            help="Repo hierarchy for this directory",
+        )
+
+        # directory remove
+        rm_parser = dir_sub.add_parser(
+            "remove",
+            help="Remove a target directory from the configuration",
+        )
+        rm_parser.add_argument("path", help="Directory path to remove")
+
+    @classmethod
+    def process_cli_command(
+        cls,
+        args: argparse.Namespace,
+        config: Config,
+    ) -> None:
+        """Process directory commands."""
+        cmd = getattr(args, "directory_command", None)
+        if cmd is None:
+            cls._show_usage()
+            return
+
+        if cmd == "list":
+            cls.list_directories(config)
+        elif cmd == "add":
+            cls.add_directory(args, config)
+        elif cmd == "remove":
+            config.remove_directory(args.path)
+
+    @staticmethod
+    def _show_usage() -> None:
+        message(
+            "Usage: agent-manager directory <command>",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+        message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        message(
+            "Available commands:",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+        message(
+            "  list      List configured target directories",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+        message(
+            "  add       Add a target directory",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+        message(
+            "  remove    Remove a target directory",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+
+    @staticmethod
+    def list_directories(config: Config) -> None:
+        """List configured directories with manifest info."""
+        if not config.exists():
+            message(
+                "No configuration found. "
+                "Run 'agent-manager config init'.",
+                MessageType.WARNING,
+                VerbosityLevel.ALWAYS,
+            )
+            return
+
+        config_data = config.read()
+        directories = config_data.get("directories", {})
+
+        if not directories:
+            message(
+                "No directories configured.",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+            message(
+                "Use 'agent-manager directory add <path>' to add one.",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+            return
+
+        message(
+            "\n=== Configured Directories ===\n",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+
+        for path_str, dir_config in sorted(directories.items()):
+            if dir_config is None:
+                dir_config = {}
+
+            # Resolve path for detection
+            resolved = Path(
+                path_str.replace("HOME", str(Path.home()))
+            ).expanduser()
+
+            dir_type = dir_config.get("type", "auto")
+            detected = AbstractRepo.detect_directory(resolved)
+            agents = dir_config.get("agents")
+            hierarchy = dir_config.get("hierarchy")
+
+            agents_str = ", ".join(agents) if agents else "(defaults)"
+            hierarchy_str = (
+                " -> ".join(hierarchy) if hierarchy else "(defaults)"
+            )
+
+            # Read manifest for last_synced
+            manifest = read_manifest(resolved)
+            last_synced = manifest.get("last_synced", "never")
+            file_count = len(manifest.get("files", []))
+
+            message(
+                f"  {path_str}",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+            message(
+                f"    Type: {dir_type} (detected: {detected})",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+            message(
+                f"    Agents: {agents_str}",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+            message(
+                f"    Hierarchy: {hierarchy_str}",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+            message(
+                f"    Last synced: {last_synced} "
+                f"({file_count} managed files)",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+            message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+
+    @staticmethod
+    def add_directory(args: argparse.Namespace, config: Config) -> None:
+        """Add a directory to the config with optional auto-detection."""
+        dir_type = getattr(args, "dir_type", None)
+
+        if dir_type is None:
+            resolved = Path(
+                args.path.replace("HOME", str(Path.home()))
+            ).expanduser()
+            detected = AbstractRepo.detect_directory(resolved)
+            if detected:
+                dir_type = detected
+                message(
+                    f"Auto-detected type: {detected}",
+                    MessageType.INFO,
+                    VerbosityLevel.VERBOSE,
+                )
+
+        config.add_directory(
+            args.path,
+            dir_type=dir_type,
+            agents=getattr(args, "agents", None),
+            hierarchy=getattr(args, "hierarchy", None),
+        )

--- a/agent_manager/cli_extensions/plugin_commands.py
+++ b/agent_manager/cli_extensions/plugin_commands.py
@@ -1,0 +1,480 @@
+"""Consolidated CLI commands for plugin management.
+
+Groups all plugin enable/disable/list/show/configure commands under
+``agent-manager plugins [agents|repos|mergers] <action>``.
+"""
+
+import argparse
+import sys
+
+from agent_manager.config import Config
+from agent_manager.core import (
+    MergerRegistry,
+    discover_agent_plugins,
+    discover_repo_types,
+)
+from agent_manager.output import MessageType, VerbosityLevel, message
+from agent_manager.utils import get_disabled_plugins, set_plugin_enabled
+
+
+class PluginCommands:
+    """Manages all plugin-related CLI commands."""
+
+    def __init__(self, merger_registry: MergerRegistry | None = None):
+        self.merger_registry = merger_registry
+
+    @staticmethod
+    def add_cli_arguments(subparsers) -> None:
+        """Register the ``plugins`` command group."""
+        plugins_parser = subparsers.add_parser(
+            "plugins",
+            help="Manage agent, repo, and merger plugins",
+        )
+        plugins_sub = plugins_parser.add_subparsers(
+            dest="plugins_category",
+            help="Plugin category",
+        )
+
+        # --- plugins agents ---
+        agents_parser = plugins_sub.add_parser(
+            "agents", help="Manage agent plugins",
+        )
+        agents_sub = agents_parser.add_subparsers(
+            dest="plugins_action", help="Agent plugin actions",
+        )
+        agents_sub.add_parser("list", help="List agent plugins")
+        p = agents_sub.add_parser("enable", help="Enable an agent plugin")
+        p.add_argument("name", help="Agent name")
+        p = agents_sub.add_parser("disable", help="Disable an agent plugin")
+        p.add_argument("name", help="Agent name")
+
+        # --- plugins repos ---
+        repos_parser = plugins_sub.add_parser(
+            "repos", help="Manage repo type plugins",
+        )
+        repos_sub = repos_parser.add_subparsers(
+            dest="plugins_action", help="Repo plugin actions",
+        )
+        repos_sub.add_parser("list", help="List repo type plugins")
+        p = repos_sub.add_parser("enable", help="Enable a repo plugin")
+        p.add_argument("name", help="Repo type name")
+        p = repos_sub.add_parser("disable", help="Disable a repo plugin")
+        p.add_argument("name", help="Repo type name")
+
+        # --- plugins mergers ---
+        mergers_parser = plugins_sub.add_parser(
+            "mergers", help="Manage merger plugins",
+        )
+        mergers_sub = mergers_parser.add_subparsers(
+            dest="plugins_action", help="Merger plugin actions",
+        )
+        mergers_sub.add_parser("list", help="List merger plugins")
+        p = mergers_sub.add_parser("show", help="Show merger preferences")
+        p.add_argument("name", help="Merger class name")
+        p = mergers_sub.add_parser(
+            "configure", help="Configure merger preferences",
+        )
+        p.add_argument(
+            "--merger", help="Configure a specific merger only",
+        )
+        p = mergers_sub.add_parser("enable", help="Enable a merger plugin")
+        p.add_argument("name", help="Merger name")
+        p = mergers_sub.add_parser("disable", help="Disable a merger plugin")
+        p.add_argument("name", help="Merger name")
+
+    def process_cli_command(
+        self,
+        args: argparse.Namespace,
+        config: Config | None = None,
+    ) -> None:
+        """Dispatch to the correct plugin category handler."""
+        category = getattr(args, "plugins_category", None)
+        if category is None:
+            self._show_usage()
+            return
+
+        action = getattr(args, "plugins_action", None)
+
+        if category == "agents":
+            self._handle_agents(action, args)
+        elif category == "repos":
+            self._handle_repos(action, args)
+        elif category == "mergers":
+            self._handle_mergers(action, args, config)
+
+    @staticmethod
+    def _show_usage() -> None:
+        message(
+            "Usage: agent-manager plugins <category> <action>",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+        message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        message(
+            "Categories:",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+        message(
+            "  agents    Manage agent plugins",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+        message(
+            "  repos     Manage repo type plugins",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+        message(
+            "  mergers   Manage merger plugins",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+
+    # ------------------------------------------------------------------
+    # Agents
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _handle_agents(action: str | None, args: argparse.Namespace) -> None:
+        if action is None:
+            message(
+                "Usage: agent-manager plugins agents "
+                "[list|enable|disable]",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+            return
+
+        if action == "list":
+            PluginCommands._list_agents()
+        elif action in ("enable", "disable"):
+            enabled = action == "enable"
+            if not set_plugin_enabled("agents", args.name, enabled=enabled):
+                sys.exit(1)
+
+    @staticmethod
+    def _list_agents() -> None:
+        disabled = get_disabled_plugins().get("agents", [])
+        plugins = discover_agent_plugins()
+
+        message(
+            "\n=== Agent Plugins ===\n",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+
+        if not plugins and not disabled:
+            message(
+                "No agent plugins found.",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+            return
+
+        if plugins:
+            message(
+                "Installed:", MessageType.NORMAL, VerbosityLevel.ALWAYS,
+            )
+            for name in sorted(plugins.keys()):
+                pkg = plugins[name]["package_name"]
+                message(
+                    f"  {name} ({pkg})",
+                    MessageType.NORMAL,
+                    VerbosityLevel.ALWAYS,
+                )
+            message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+
+        if disabled:
+            message(
+                "Disabled:", MessageType.NORMAL, VerbosityLevel.ALWAYS,
+            )
+            for name in disabled:
+                message(
+                    f"  {name}",
+                    MessageType.WARNING,
+                    VerbosityLevel.ALWAYS,
+                )
+            message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+
+        message(
+            f"Total: {len(plugins)} enabled, {len(disabled)} disabled",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+
+    # ------------------------------------------------------------------
+    # Repos
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _handle_repos(action: str | None, args: argparse.Namespace) -> None:
+        if action is None:
+            message(
+                "Usage: agent-manager plugins repos "
+                "[list|enable|disable]",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+            return
+
+        if action == "list":
+            PluginCommands._list_repos()
+        elif action in ("enable", "disable"):
+            enabled = action == "enable"
+            if not set_plugin_enabled("repos", args.name, enabled=enabled):
+                sys.exit(1)
+
+    @staticmethod
+    def _list_repos() -> None:
+        disabled = get_disabled_plugins().get("repos", [])
+        repo_types = discover_repo_types()
+
+        message(
+            "\n=== Repo Type Plugins ===\n",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+
+        if not repo_types and not disabled:
+            message(
+                "No repo type plugins found.",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+            return
+
+        if repo_types:
+            message(
+                "Installed:", MessageType.NORMAL, VerbosityLevel.ALWAYS,
+            )
+            for repo_class in repo_types:
+                message(
+                    f"  {repo_class.REPO_TYPE} ({repo_class.__module__})",
+                    MessageType.NORMAL,
+                    VerbosityLevel.ALWAYS,
+                )
+            message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+
+        if disabled:
+            message(
+                "Disabled:", MessageType.NORMAL, VerbosityLevel.ALWAYS,
+            )
+            for name in disabled:
+                message(
+                    f"  {name}",
+                    MessageType.WARNING,
+                    VerbosityLevel.ALWAYS,
+                )
+            message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+
+        message(
+            f"Total: {len(repo_types)} enabled, {len(disabled)} disabled",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+
+    # ------------------------------------------------------------------
+    # Mergers
+    # ------------------------------------------------------------------
+    def _handle_mergers(
+        self,
+        action: str | None,
+        args: argparse.Namespace,
+        config: Config | None = None,
+    ) -> None:
+        if action is None:
+            message(
+                "Usage: agent-manager plugins mergers "
+                "[list|show|configure|enable|disable]",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+            return
+
+        if action == "list":
+            self._list_mergers()
+        elif action == "show":
+            self._show_merger(args.name)
+        elif action == "configure":
+            merger_name = getattr(args, "merger", None)
+            self._configure_mergers(config, merger_name)
+        elif action in ("enable", "disable"):
+            enabled = action == "enable"
+            if not set_plugin_enabled("mergers", args.name, enabled=enabled):
+                sys.exit(1)
+
+    def _list_mergers(self) -> None:
+        from agent_manager.core.mergers import discover_merger_classes
+
+        if self.merger_registry is None:
+            message(
+                "Merger registry not available.",
+                MessageType.ERROR,
+                VerbosityLevel.ALWAYS,
+            )
+            return
+
+        disabled = get_disabled_plugins().get("mergers", [])
+        registered = self.merger_registry.list_registered_mergers()
+
+        message(
+            "\n=== Merger Plugins ===\n",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+
+        if registered["extensions"]:
+            message(
+                "Extension-based:",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+            for ext in sorted(registered["extensions"]):
+                merger = self.merger_registry.extension_mergers[ext]
+                message(
+                    f"  {ext} -> {merger.__name__}",
+                    MessageType.NORMAL,
+                    VerbosityLevel.ALWAYS,
+                )
+            message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+
+        message(
+            f"Default: {registered['default']}",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+        message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+
+        # Unregistered
+        all_discovered = discover_merger_classes()
+        registered_classes = set(
+            self.merger_registry.extension_mergers.values()
+        )
+        registered_classes.update(
+            self.merger_registry.filename_mergers.values()
+        )
+        registered_classes.add(self.merger_registry.default_merger)
+        unregistered = [m for m in all_discovered if m not in registered_classes]
+
+        if unregistered:
+            message(
+                "Available but unregistered:",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+            for cls in sorted(unregistered, key=lambda c: c.__name__):
+                exts = getattr(cls, "FILE_EXTENSIONS", [])
+                ext_str = f" ({', '.join(exts)})" if exts else ""
+                message(
+                    f"  {cls.__name__}{ext_str}",
+                    MessageType.NORMAL,
+                    VerbosityLevel.ALWAYS,
+                )
+            message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+
+        if disabled:
+            message(
+                "Disabled:", MessageType.NORMAL, VerbosityLevel.ALWAYS,
+            )
+            for name in disabled:
+                message(
+                    f"  {name}",
+                    MessageType.WARNING,
+                    VerbosityLevel.ALWAYS,
+                )
+            message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+
+    def _show_merger(self, merger_name: str) -> None:
+        merger_class = self._find_merger_class(merger_name)
+        if not merger_class:
+            message(
+                f"Merger '{merger_name}' not found",
+                MessageType.ERROR,
+                VerbosityLevel.ALWAYS,
+            )
+            sys.exit(1)
+
+        prefs = merger_class.merge_preferences()
+        if not prefs:
+            message(
+                f"\n{merger_name} has no configurable preferences.\n",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+            return
+
+        message(
+            f"\n=== {merger_name} Preferences ===\n",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+        for pref_name, schema in prefs.items():
+            message(
+                f"{pref_name}:",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+            message(
+                f"  Type: {schema.get('type', 'unknown')}",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+            message(
+                f"  Default: {schema.get('default')}",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+            desc = schema.get("description", "")
+            if desc:
+                message(
+                    f"  Description: {desc}",
+                    MessageType.NORMAL,
+                    VerbosityLevel.ALWAYS,
+                )
+            message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+
+    def _configure_mergers(
+        self,
+        config: Config | None,
+        specific_merger: str | None = None,
+    ) -> None:
+        if config is None:
+            message(
+                "Config required for merger configuration.",
+                MessageType.ERROR,
+                VerbosityLevel.ALWAYS,
+            )
+            sys.exit(1)
+
+        # Delegate to the existing MergerCommands logic
+        from agent_manager.cli_extensions.merger_commands import (
+            MergerCommands,
+        )
+
+        if self.merger_registry is None:
+            message(
+                "Merger registry not available.",
+                MessageType.ERROR,
+                VerbosityLevel.ALWAYS,
+            )
+            sys.exit(1)
+
+        mc = MergerCommands(self.merger_registry)
+        mc.configure_mergers(config, specific_merger)
+
+    def _find_merger_class(self, merger_name: str) -> type | None:
+        from agent_manager.core.mergers import discover_merger_classes
+
+        if self.merger_registry is None:
+            return None
+
+        all_classes: set[type] = set()
+        all_classes.update(self.merger_registry.extension_mergers.values())
+        all_classes.update(self.merger_registry.filename_mergers.values())
+        all_classes.add(self.merger_registry.default_merger)
+        for cls in discover_merger_classes():
+            all_classes.add(cls)
+
+        for cls in all_classes:
+            if cls.__name__ == merger_name:
+                return cls
+        return None

--- a/agent_manager/cli_extensions/repo_config_commands.py
+++ b/agent_manager/cli_extensions/repo_config_commands.py
@@ -1,0 +1,170 @@
+"""CLI commands for managing repo entries in the configuration.
+
+This manages *config entries* (``repo add/remove/list``), not repo
+*plugins* (which live under ``plugins repos``).
+"""
+
+import argparse
+
+from agent_manager.config import Config
+from agent_manager.output import MessageType, VerbosityLevel, message
+
+
+class RepoConfigCommands:
+    """Manages CLI commands for repo entries in the config."""
+
+    @staticmethod
+    def add_cli_arguments(subparsers) -> None:
+        """Add repo config commands to the argument parser."""
+        repo_parser = subparsers.add_parser(
+            "repo",
+            help="Manage repository entries in the configuration",
+        )
+        repo_sub = repo_parser.add_subparsers(
+            dest="repo_command",
+            help="Repo commands",
+        )
+
+        # repo list
+        repo_sub.add_parser(
+            "list",
+            help="List configured repos",
+        )
+
+        # repo add
+        add_parser = repo_sub.add_parser(
+            "add",
+            help="Add a repo to the configuration",
+        )
+        add_parser.add_argument("name", help="Repo name")
+        add_parser.add_argument("url", help="Repository URL")
+        add_parser.add_argument(
+            "--type",
+            dest="repo_type",
+            help="Repository type (auto-detected if omitted)",
+        )
+
+        # repo remove
+        rm_parser = repo_sub.add_parser(
+            "remove",
+            help="Remove a repo from the configuration",
+        )
+        rm_parser.add_argument("name", help="Repo name to remove")
+        rm_parser.add_argument(
+            "--force",
+            action="store_true",
+            help=(
+                "Remove even if referenced in default_hierarchy or "
+                "directory hierarchies (cascade-removes references)"
+            ),
+        )
+
+    @classmethod
+    def process_cli_command(
+        cls,
+        args: argparse.Namespace,
+        config: Config,
+    ) -> None:
+        """Process repo config commands."""
+        cmd = getattr(args, "repo_command", None)
+        if cmd is None:
+            cls._show_usage()
+            return
+
+        if cmd == "list":
+            cls.list_repos(config)
+        elif cmd == "add":
+            config.add_repo(
+                args.name,
+                args.url,
+                repo_type=getattr(args, "repo_type", None),
+            )
+        elif cmd == "remove":
+            config.remove_repo(
+                args.name,
+                force=getattr(args, "force", False),
+            )
+
+    @staticmethod
+    def _show_usage() -> None:
+        message(
+            "Usage: agent-manager repo <command>",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+        message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        message(
+            "Available commands:",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+        message(
+            "  list      List configured repos",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+        message(
+            "  add       Add a repo to the configuration",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+        message(
+            "  remove    Remove a repo from the configuration",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+
+    @staticmethod
+    def list_repos(config: Config) -> None:
+        """List configured repos."""
+        if not config.exists():
+            message(
+                "No configuration found. Run 'agent-manager config init'.",
+                MessageType.WARNING,
+                VerbosityLevel.ALWAYS,
+            )
+            return
+
+        config_data = config.read()
+        repos = config_data.get("repos", [])
+
+        if not repos:
+            message(
+                "No repos configured.",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+            message(
+                "Use 'agent-manager repo add <name> <url>' to add one.",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+            return
+
+        message(
+            "\n=== Configured Repos ===\n",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+        for entry in repos:
+            name = entry.get("name", "?")
+            url = entry.get("url", "?")
+            repo_type = entry.get("repo_type", "unknown")
+            message(
+                f"  {name} ({repo_type})",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+            message(
+                f"    URL: {url}",
+                MessageType.NORMAL,
+                VerbosityLevel.ALWAYS,
+            )
+
+        message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)
+        message(
+            f"Total: {len(repos)} repo(s)",
+            MessageType.NORMAL,
+            VerbosityLevel.ALWAYS,
+        )
+        message("", MessageType.NORMAL, VerbosityLevel.ALWAYS)

--- a/tests/cli_extensions/test_directory_commands.py
+++ b/tests/cli_extensions/test_directory_commands.py
@@ -1,0 +1,247 @@
+"""Tests for cli_extensions/directory_commands.py."""
+
+from unittest.mock import Mock, patch
+
+from agent_manager.cli_extensions.directory_commands import DirectoryCommands
+
+
+class TestDirectoryAddCliArguments:
+
+    def test_adds_directory_parser(self):
+        mock_subparsers = Mock()
+        mock_parser = Mock()
+        mock_parser.add_subparsers.return_value = Mock()
+        mock_subparsers.add_parser.return_value = mock_parser
+
+        DirectoryCommands.add_cli_arguments(mock_subparsers)
+
+        calls = [c[0][0] for c in mock_subparsers.add_parser.call_args_list]
+        assert "directory" in calls
+
+    def test_adds_subcommands(self):
+        mock_subparsers = Mock()
+        mock_dir_parser = Mock()
+        mock_dir_sub = Mock()
+        mock_dir_parser.add_subparsers.return_value = mock_dir_sub
+        mock_subparsers.add_parser.return_value = mock_dir_parser
+
+        DirectoryCommands.add_cli_arguments(mock_subparsers)
+
+        calls = [c[0][0] for c in mock_dir_sub.add_parser.call_args_list]
+        assert "list" in calls
+        assert "add" in calls
+        assert "remove" in calls
+
+
+class TestDirectoryProcessCliCommand:
+
+    def test_no_subcommand_shows_usage(self):
+        args = Mock()
+        args.directory_command = None
+        config = Mock()
+        messages = []
+
+        with patch(
+            "agent_manager.cli_extensions.directory_commands.message",
+            side_effect=lambda t, *a, **kw: messages.append(t),
+        ):
+            DirectoryCommands.process_cli_command(args, config)
+
+        output = "\n".join(messages)
+        assert "Usage: agent-manager directory" in output
+
+    def test_list_delegates(self):
+        args = Mock()
+        args.directory_command = "list"
+        config = Mock()
+
+        with patch.object(
+            DirectoryCommands, "list_directories",
+        ) as mock_list:
+            DirectoryCommands.process_cli_command(args, config)
+            mock_list.assert_called_once_with(config)
+
+    def test_add_delegates(self):
+        args = Mock()
+        args.directory_command = "add"
+        args.path = "HOME/GIT/project"
+        args.dir_type = "git"
+        args.agents = ["cursor"]
+        args.hierarchy = ["personal"]
+
+        config = Mock()
+
+        with patch.object(
+            DirectoryCommands, "add_directory",
+        ) as mock_add:
+            DirectoryCommands.process_cli_command(args, config)
+            mock_add.assert_called_once_with(args, config)
+
+    def test_remove_delegates(self):
+        args = Mock()
+        args.directory_command = "remove"
+        args.path = "HOME/GIT/project"
+
+        config = Mock()
+
+        DirectoryCommands.process_cli_command(args, config)
+        config.remove_directory.assert_called_once_with(
+            "HOME/GIT/project",
+        )
+
+
+class TestDirectoryListDirectories:
+
+    def test_no_config(self):
+        config = Mock()
+        config.exists.return_value = False
+        messages = []
+
+        with patch(
+            "agent_manager.cli_extensions.directory_commands.message",
+            side_effect=lambda t, *a, **kw: messages.append(t),
+        ):
+            DirectoryCommands.list_directories(config)
+
+        output = "\n".join(messages)
+        assert "No configuration found" in output
+
+    def test_empty_directories(self):
+        config = Mock()
+        config.exists.return_value = True
+        config.read.return_value = {"repos": [], "directories": {}}
+        messages = []
+
+        with patch(
+            "agent_manager.cli_extensions.directory_commands.message",
+            side_effect=lambda t, *a, **kw: messages.append(t),
+        ):
+            DirectoryCommands.list_directories(config)
+
+        output = "\n".join(messages)
+        assert "No directories configured" in output
+
+    @patch(
+        "agent_manager.cli_extensions.directory_commands.read_manifest",
+    )
+    @patch(
+        "agent_manager.cli_extensions.directory_commands"
+        ".AbstractRepo.detect_directory",
+    )
+    def test_lists_directories_with_manifest(
+        self, mock_detect, mock_manifest,
+    ):
+        mock_detect.return_value = "git"
+        mock_manifest.return_value = {
+            "last_synced": "2026-02-13T15:30:00",
+            "files": [
+                {"name": ".cursor/rules/test.md", "agents": ["cursor"]},
+            ],
+        }
+
+        config = Mock()
+        config.exists.return_value = True
+        config.read.return_value = {
+            "repos": [],
+            "directories": {
+                "HOME/GIT/project": {
+                    "type": "git",
+                    "agents": ["cursor"],
+                    "hierarchy": ["org", "personal"],
+                },
+            },
+        }
+        messages = []
+
+        with patch(
+            "agent_manager.cli_extensions.directory_commands.message",
+            side_effect=lambda t, *a, **kw: messages.append(t),
+        ):
+            DirectoryCommands.list_directories(config)
+
+        output = "\n".join(messages)
+        assert "HOME/GIT/project" in output
+        assert "git" in output
+        assert "cursor" in output
+        assert "org -> personal" in output
+        assert "1 managed files" in output
+
+    @patch(
+        "agent_manager.cli_extensions.directory_commands.read_manifest",
+    )
+    @patch(
+        "agent_manager.cli_extensions.directory_commands"
+        ".AbstractRepo.detect_directory",
+    )
+    def test_handles_none_dir_config(
+        self, mock_detect, mock_manifest,
+    ):
+        """Directories with None config should display defaults."""
+        mock_detect.return_value = "file"
+        mock_manifest.return_value = {"files": []}
+
+        config = Mock()
+        config.exists.return_value = True
+        config.read.return_value = {
+            "repos": [],
+            "directories": {"HOME": None},
+        }
+        messages = []
+
+        with patch(
+            "agent_manager.cli_extensions.directory_commands.message",
+            side_effect=lambda t, *a, **kw: messages.append(t),
+        ):
+            DirectoryCommands.list_directories(config)
+
+        output = "\n".join(messages)
+        assert "HOME" in output
+        assert "(defaults)" in output
+
+
+class TestDirectoryAddDirectory:
+
+    @patch(
+        "agent_manager.cli_extensions.directory_commands"
+        ".AbstractRepo.detect_directory",
+    )
+    def test_add_with_auto_detect(self, mock_detect):
+        mock_detect.return_value = "git"
+
+        args = Mock()
+        args.path = "HOME/GIT/project"
+        args.dir_type = None
+        args.agents = None
+        args.hierarchy = None
+
+        config = Mock()
+
+        with patch(
+            "agent_manager.cli_extensions.directory_commands.message",
+        ):
+            DirectoryCommands.add_directory(args, config)
+
+        config.add_directory.assert_called_once_with(
+            "HOME/GIT/project",
+            dir_type="git",
+            agents=None,
+            hierarchy=None,
+        )
+
+    def test_add_with_explicit_type(self):
+        args = Mock()
+        args.path = "HOME"
+        args.dir_type = "local"
+        args.agents = ["cursor", "claude"]
+        args.hierarchy = None
+
+        config = Mock()
+
+        DirectoryCommands.add_directory(args, config)
+
+        config.add_directory.assert_called_once_with(
+            "HOME",
+            dir_type="local",
+            agents=["cursor", "claude"],
+            hierarchy=None,
+        )

--- a/tests/cli_extensions/test_plugin_commands.py
+++ b/tests/cli_extensions/test_plugin_commands.py
@@ -1,0 +1,210 @@
+"""Tests for cli_extensions/plugin_commands.py."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from agent_manager.cli_extensions.plugin_commands import PluginCommands
+
+
+class TestPluginCommandsAddCliArguments:
+
+    def test_adds_plugins_parser(self):
+        mock_subparsers = Mock()
+        mock_parser = Mock()
+        mock_sub = Mock()
+        mock_parser.add_subparsers.return_value = mock_sub
+
+        # Each category parser also needs add_subparsers
+        cat_parser = Mock()
+        cat_sub = Mock()
+        cat_parser.add_subparsers.return_value = cat_sub
+        mock_sub.add_parser.return_value = cat_parser
+
+        mock_subparsers.add_parser.return_value = mock_parser
+
+        PluginCommands.add_cli_arguments(mock_subparsers)
+
+        calls = [c[0][0] for c in mock_subparsers.add_parser.call_args_list]
+        assert "plugins" in calls
+
+    def test_adds_category_parsers(self):
+        mock_subparsers = Mock()
+        mock_plugins_parser = Mock()
+        mock_plugins_sub = Mock()
+        mock_plugins_parser.add_subparsers.return_value = mock_plugins_sub
+
+        # Category parsers
+        mock_cat = Mock()
+        mock_cat.add_subparsers.return_value = Mock()
+        mock_plugins_sub.add_parser.return_value = mock_cat
+
+        mock_subparsers.add_parser.return_value = mock_plugins_parser
+
+        PluginCommands.add_cli_arguments(mock_subparsers)
+
+        calls = [
+            c[0][0]
+            for c in mock_plugins_sub.add_parser.call_args_list
+        ]
+        assert "agents" in calls
+        assert "repos" in calls
+        assert "mergers" in calls
+
+
+class TestPluginCommandsProcess:
+
+    def test_no_category_shows_usage(self):
+        pc = PluginCommands()
+        args = Mock()
+        args.plugins_category = None
+        messages = []
+
+        with patch(
+            "agent_manager.cli_extensions.plugin_commands.message",
+            side_effect=lambda t, *a, **kw: messages.append(t),
+        ):
+            pc.process_cli_command(args)
+
+        output = "\n".join(messages)
+        assert "Usage: agent-manager plugins" in output
+
+    def test_agents_category_dispatches(self):
+        pc = PluginCommands()
+        args = Mock()
+        args.plugins_category = "agents"
+        args.plugins_action = "list"
+
+        with patch.object(
+            PluginCommands, "_handle_agents",
+        ) as mock_h:
+            pc.process_cli_command(args)
+            mock_h.assert_called_once_with("list", args)
+
+    def test_repos_category_dispatches(self):
+        pc = PluginCommands()
+        args = Mock()
+        args.plugins_category = "repos"
+        args.plugins_action = "list"
+
+        with patch.object(
+            PluginCommands, "_handle_repos",
+        ) as mock_h:
+            pc.process_cli_command(args)
+            mock_h.assert_called_once_with("list", args)
+
+    def test_mergers_category_dispatches(self):
+        pc = PluginCommands()
+        args = Mock()
+        args.plugins_category = "mergers"
+        args.plugins_action = "list"
+
+        with patch.object(
+            PluginCommands, "_handle_mergers",
+        ) as mock_h:
+            pc.process_cli_command(args, config=Mock())
+            mock_h.assert_called_once()
+
+
+class TestPluginCommandsAgents:
+
+    def test_no_action_shows_usage(self):
+        messages = []
+
+        with patch(
+            "agent_manager.cli_extensions.plugin_commands.message",
+            side_effect=lambda t, *a, **kw: messages.append(t),
+        ):
+            PluginCommands._handle_agents(None, Mock())
+
+        output = "\n".join(messages)
+        assert "plugins agents" in output
+
+    @patch("agent_manager.cli_extensions.plugin_commands.get_disabled_plugins")
+    @patch("agent_manager.cli_extensions.plugin_commands.discover_agent_plugins")
+    def test_list_agents(self, mock_disc, mock_disabled):
+        mock_disc.return_value = {
+            "claude": {"package_name": "am_agent_claude"},
+        }
+        mock_disabled.return_value = {"agents": []}
+        messages = []
+
+        with patch(
+            "agent_manager.cli_extensions.plugin_commands.message",
+            side_effect=lambda t, *a, **kw: messages.append(t),
+        ):
+            PluginCommands._handle_agents("list", Mock())
+
+        output = "\n".join(messages)
+        assert "claude" in output
+
+    @patch("agent_manager.cli_extensions.plugin_commands.set_plugin_enabled")
+    def test_enable_agent(self, mock_enable):
+        mock_enable.return_value = True
+        args = Mock()
+        args.name = "claude"
+
+        PluginCommands._handle_agents("enable", args)
+
+        mock_enable.assert_called_once_with(
+            "agents", "claude", enabled=True,
+        )
+
+
+class TestPluginCommandsRepos:
+
+    @patch("agent_manager.cli_extensions.plugin_commands.get_disabled_plugins")
+    @patch("agent_manager.cli_extensions.plugin_commands.discover_repo_types")
+    def test_list_repos(self, mock_disc, mock_disabled):
+        mock_repo = Mock()
+        mock_repo.REPO_TYPE = "git"
+        mock_repo.__module__ = "agent_manager.plugins.repos.git_repo"
+        mock_disc.return_value = [mock_repo]
+        mock_disabled.return_value = {"repos": []}
+        messages = []
+
+        with patch(
+            "agent_manager.cli_extensions.plugin_commands.message",
+            side_effect=lambda t, *a, **kw: messages.append(t),
+        ):
+            PluginCommands._handle_repos("list", Mock())
+
+        output = "\n".join(messages)
+        assert "git" in output
+
+    @patch("agent_manager.cli_extensions.plugin_commands.set_plugin_enabled")
+    def test_disable_repo(self, mock_enable):
+        mock_enable.return_value = True
+        args = Mock()
+        args.name = "git"
+
+        PluginCommands._handle_repos("disable", args)
+
+        mock_enable.assert_called_once_with(
+            "repos", "git", enabled=False,
+        )
+
+
+class TestPluginCommandsMergers:
+
+    def test_no_action_shows_usage(self):
+        pc = PluginCommands()
+        messages = []
+
+        with patch(
+            "agent_manager.cli_extensions.plugin_commands.message",
+            side_effect=lambda t, *a, **kw: messages.append(t),
+        ):
+            pc._handle_mergers(None, Mock())
+
+        output = "\n".join(messages)
+        assert "plugins mergers" in output
+
+    def test_show_merger_not_found(self):
+        pc = PluginCommands(merger_registry=Mock())
+        with patch.object(pc, "_find_merger_class", return_value=None):
+            with pytest.raises(SystemExit):
+                with patch(
+                    "agent_manager.cli_extensions.plugin_commands.message",
+                ):
+                    pc._handle_mergers("show", Mock(name="NoSuch"))

--- a/tests/cli_extensions/test_repo_config_commands.py
+++ b/tests/cli_extensions/test_repo_config_commands.py
@@ -1,0 +1,179 @@
+"""Tests for cli_extensions/repo_config_commands.py."""
+
+from unittest.mock import Mock, patch
+
+from agent_manager.cli_extensions.repo_config_commands import RepoConfigCommands
+
+
+class TestRepoConfigAddCliArguments:
+
+    def test_adds_repo_parser(self):
+        mock_subparsers = Mock()
+        mock_parser = Mock()
+        mock_parser.add_subparsers.return_value = Mock()
+        mock_subparsers.add_parser.return_value = mock_parser
+
+        RepoConfigCommands.add_cli_arguments(mock_subparsers)
+
+        calls = [c[0][0] for c in mock_subparsers.add_parser.call_args_list]
+        assert "repo" in calls
+
+    def test_adds_subcommands(self):
+        mock_subparsers = Mock()
+        mock_repo_parser = Mock()
+        mock_repo_sub = Mock()
+        mock_repo_parser.add_subparsers.return_value = mock_repo_sub
+
+        mock_subparsers.add_parser.return_value = mock_repo_parser
+
+        RepoConfigCommands.add_cli_arguments(mock_subparsers)
+
+        calls = [c[0][0] for c in mock_repo_sub.add_parser.call_args_list]
+        assert "list" in calls
+        assert "add" in calls
+        assert "remove" in calls
+
+
+class TestRepoConfigProcessCliCommand:
+
+    def test_no_subcommand_shows_usage(self):
+        args = Mock()
+        args.repo_command = None
+        config = Mock()
+        messages = []
+
+        with patch(
+            "agent_manager.cli_extensions.repo_config_commands.message",
+            side_effect=lambda t, *a, **kw: messages.append(t),
+        ):
+            RepoConfigCommands.process_cli_command(args, config)
+
+        output = "\n".join(messages)
+        assert "Usage: agent-manager repo" in output
+
+    def test_list_delegates(self):
+        args = Mock()
+        args.repo_command = "list"
+        config = Mock()
+
+        with patch.object(
+            RepoConfigCommands, "list_repos",
+        ) as mock_list:
+            RepoConfigCommands.process_cli_command(args, config)
+            mock_list.assert_called_once_with(config)
+
+    def test_add_delegates(self):
+        args = Mock()
+        args.repo_command = "add"
+        args.name = "personal"
+        args.url = "file:///tmp/personal"
+        args.repo_type = "file"
+
+        config = Mock()
+
+        RepoConfigCommands.process_cli_command(args, config)
+
+        config.add_repo.assert_called_once_with(
+            "personal", "file:///tmp/personal", repo_type="file",
+        )
+
+    def test_add_auto_detect_type(self):
+        args = Mock()
+        args.repo_command = "add"
+        args.name = "org"
+        args.url = "https://github.com/org/repo.git"
+        args.repo_type = None
+
+        config = Mock()
+
+        RepoConfigCommands.process_cli_command(args, config)
+
+        config.add_repo.assert_called_once_with(
+            "org", "https://github.com/org/repo.git", repo_type=None,
+        )
+
+    def test_remove_delegates(self):
+        args = Mock()
+        args.repo_command = "remove"
+        args.name = "personal"
+        args.force = False
+
+        config = Mock()
+
+        RepoConfigCommands.process_cli_command(args, config)
+
+        config.remove_repo.assert_called_once_with("personal", force=False)
+
+    def test_remove_with_force(self):
+        args = Mock()
+        args.repo_command = "remove"
+        args.name = "personal"
+        args.force = True
+
+        config = Mock()
+
+        RepoConfigCommands.process_cli_command(args, config)
+
+        config.remove_repo.assert_called_once_with("personal", force=True)
+
+
+class TestRepoConfigListRepos:
+
+    def test_no_config(self):
+        config = Mock()
+        config.exists.return_value = False
+        messages = []
+
+        with patch(
+            "agent_manager.cli_extensions.repo_config_commands.message",
+            side_effect=lambda t, *a, **kw: messages.append(t),
+        ):
+            RepoConfigCommands.list_repos(config)
+
+        output = "\n".join(messages)
+        assert "No configuration found" in output
+
+    def test_empty_repos(self):
+        config = Mock()
+        config.exists.return_value = True
+        config.read.return_value = {"repos": []}
+        messages = []
+
+        with patch(
+            "agent_manager.cli_extensions.repo_config_commands.message",
+            side_effect=lambda t, *a, **kw: messages.append(t),
+        ):
+            RepoConfigCommands.list_repos(config)
+
+        output = "\n".join(messages)
+        assert "No repos configured" in output
+
+    def test_lists_repos(self):
+        config = Mock()
+        config.exists.return_value = True
+        config.read.return_value = {
+            "repos": [
+                {
+                    "name": "org",
+                    "url": "https://github.com/org/repo.git",
+                    "repo_type": "git",
+                },
+                {
+                    "name": "personal",
+                    "url": "file:///tmp/personal",
+                    "repo_type": "file",
+                },
+            ],
+        }
+        messages = []
+
+        with patch(
+            "agent_manager.cli_extensions.repo_config_commands.message",
+            side_effect=lambda t, *a, **kw: messages.append(t),
+        ):
+            RepoConfigCommands.list_repos(config)
+
+        output = "\n".join(messages)
+        assert "org (git)" in output
+        assert "personal (file)" in output
+        assert "Total: 2 repo(s)" in output

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -20,7 +20,7 @@ class TestCLIArgumentParsing:
         assert "Manage your AI agents from a hierarchy of directories" in captured.out
         assert "runtime commands" in captured.out
         assert "plugin commands" in captured.out
-        assert "configuration commands" in captured.out
+        assert "config" in captured.out
 
     def test_version_verbosity_levels(self):
         """Test verbosity levels are correctly parsed."""

--- a/tests/test_agent_manager.py
+++ b/tests/test_agent_manager.py
@@ -334,11 +334,11 @@ class TestRunCommand:
 
                             mock_agent.assert_called_once()
 
-    def test_run_command_with_agent_flag(self):
-        """Test run command with specific agent selection."""
+    def test_run_command_with_all_flag(self):
+        """Test run command with --all flag."""
         mock_config_data = {"hierarchy": []}
 
-        with patch("sys.argv", ["agent-manager", "run", "--agent", "all"]):
+        with patch("sys.argv", ["agent-manager", "run", "--all"]):
             with patch("agent_manager.agent_manager.Config") as mock_config:
                 with patch("agent_manager.agent_manager.update_repositories"):
                     with patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent:
@@ -349,7 +349,7 @@ class TestRunCommand:
                                 main()
 
                                 args = mock_agent.call_args[0][0]
-                                assert args.agent == "all"
+                                assert args.run_all is True
 
     def test_run_updates_repos_before_running_agents(self):
         """Test that repositories are updated before running agents."""
@@ -482,7 +482,7 @@ class TestIntegration:
             ]
         }
 
-        with patch("sys.argv", ["agent-manager", "-vv", "run", "--agent", "all"]):
+        with patch("sys.argv", ["agent-manager", "-vv", "run", "--all"]):
             with patch("agent_manager.agent_manager.Config") as mock_config:
                 with patch("agent_manager.agent_manager.update_repositories") as mock_update:
                     with patch("agent_manager.agent_manager.AgentCommands.process_cli_command") as mock_agent:
@@ -508,7 +508,7 @@ class TestIntegration:
                             # Verify agent command args
                             args, config_data = mock_agent.call_args[0]
                             assert args.command == "run"
-                            assert args.agent == "all"
+                            assert args.run_all is True
                             assert config_data == mock_config_data
 
     def test_config_command_workflow(self):


### PR DESCRIPTION
## Summary

Restructures the agent-manager CLI for the V2 repos + directories architecture:

- **Run command rewrite**: Replaces `--agent`/`--scope` with `--all`, `--directory` (repeatable), `--agent` (repeatable), `--force`, `--non-interactive`. Adds `resolve_directory_path()` for `HOME` keyword and `~` expansion.
- **Top-level `repo` command**: `repo add/remove/list` to manage config repo entries. `remove` refuses when referenced unless `--force` cascades.
- **Top-level `directory` command**: `directory add/remove/list` to manage target directories. `add` auto-detects VCS type. `list` reads manifests for `last_synced` and managed file counts.
- **Consolidated `plugins` namespace**: `plugins agents/repos/mergers` with enable/disable/list/show/configure. Old `agents`/`repos`/`mergers` commands kept as legacy aliases.
- **Updated main CLI routing**: New `COMMAND_GROUPS` help text with runtime, config entity, config file, and plugin groupings.

## Commits

1. `refactor: rewrite run command with --directory, --all, --agent, --force, --non-interactive`
2. `feat: add top-level repo command with cascade remove`
3. `feat: add top-level directory command`
4. `feat: consolidate plugin commands under plugins namespace`
5. `refactor: update main CLI routing and help text for V2`

## New Files

- `agent_manager/cli_extensions/repo_config_commands.py` + tests
- `agent_manager/cli_extensions/directory_commands.py` + tests
- `agent_manager/cli_extensions/plugin_commands.py` + tests

## Test Plan

- [x] 693 tests pass (16 deselected are pre-existing `am_merger_smart_markdown` environment issues)
- [x] All new commands have dedicated test files
- [x] Integration tests updated for new flag structure
- [x] `ruff check` passes on all modified files


Made with [Cursor](https://cursor.com)